### PR TITLE
Make python-isal a requirement on macos as well.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_data={"xopen": ["py.typed"]},
     extras_require={
         'dev': ['pytest'],
-        ':sys_platform=="linux" and python_implementation != "PyPy"': ['isal>=0.3.0']
+        ':(sys_platform=="linux" or sys_platform=="darwin") and python_implementation != "PyPy"': ['isal>=0.4.0']
     },
     python_requires='>=3.6',
     classifiers=[


### PR DESCRIPTION
Wheels are now also build for macos as well on python-isal.
A twine check is run as part of the build for python-isal. Thanks for pointing me to cibuildwheel. It works great. 
https://github.com/pycompression/python-isal/blob/develop/.github/workflows/ci.yml
A lot of this can be copy pasted and applied to dnaio and cutadapt I think.