### PR TITLE
Use python -m isal.igzip as a replacement for pigz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     package_data={"xopen": ["py.typed"]},
     extras_require={
         'dev': ['pytest'],
-        ':(sys_platform=="linux" or sys_platform=="darwin") and python_implementation != "PyPy"': ['isal>=0.4.0']
+        ':(sys_platform=="linux" or sys_platform=="darwin") and python_implementation != "PyPy"': ['isal>=0.5.0']
     },
     python_requires='>=3.6',
     classifiers=[

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -9,7 +9,6 @@ import sys
 import io
 import os
 import bz2
-import time
 import stat
 import signal
 import pathlib
@@ -298,9 +297,9 @@ class PipedCompressionReader(Closing):
         assert self.process.stderr is not None
         self._stderr = io.TextIOWrapper(self.process.stderr)
         self.closed = False
-        # Give the subprocess a little bit of time to report any errors (such as
-        # a non-existing file)
-        time.sleep(0.05)
+        # Peek the first character(s) of stdout. This will ensure the program
+        # has started before checking any errors.
+        self.process.stdout.peek(1)  # type: ignore  # stdout is io.BufferedReader if set to PIPE.
         self._raise_if_error()
 
     def __repr__(self):

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -300,7 +300,7 @@ class PipedCompressionReader(Closing):
         self.closed = False
         # Give the subprocess a little bit of time to report any errors (such as
         # a non-existing file)
-        time.sleep(0.01)
+        time.sleep(0.05)
         self._raise_if_error()
 
     def __repr__(self):


### PR DESCRIPTION
fixes #48 

Here are some benchmarks with a real-world scenario: cutadapt.

Using igzip (only available via conda installation):
```
$ hyperfine -w 3 -r  10 'cutadapt -a AGATCGGAAGAG 5000000reads.fastq.gz -Z --cores 4 -o ramdisk/big2.cut.fastq.gz'
Benchmark #1: cutadapt -a AGATCGGAAGAG 5000000reads.fastq.gz -Z --cores 4 -o ramdisk/big2.cut.fastq.gz
  Time (mean ± σ):      8.731 s ±  0.083 s    [User: 42.513 s, System: 3.043 s]
  Range (min … max):    8.608 s …  8.864 s    10 runs
```
Wall clock time: 8.7 sec. Compute time: 45.5 sec.

Using pigz. Generally available (gzip availability is even better, but performs worse):
```
$ hyperfine -w 3 -r  10 'cutadapt -a AGATCGGAAGAG 5000000reads.fastq.gz -Z --cores 4 -o ramdisk/big2.cut.fastq.gz'
Benchmark #1: cutadapt -a AGATCGGAAGAG 5000000reads.fastq.gz -Z --cores 4 -o ramdisk/big2.cut.fastq.gz
  Time (mean ± σ):     10.245 s ±  0.071 s    [User: 77.794 s, System: 3.061 s]
  Range (min … max):   10.156 s … 10.382 s    10 runs
```
Wall clock time: 10.2 sec. Compute time: 80.8 sec.
The wall clock increase is not too bad. But do note this is a 6 core 12 thread system. On a 4-thread system the wall-clock time would have scaled linearly with the compute time.

Using `python -m isal.igzip`. Due to the latest changes available on Linux and Mac if xopen is installed (== always from our perspective, unless PyPy is used.).
```
$ hyperfine -w 3 -r  10 'cutadapt -a AGATCGGAAGAG 5000000reads.fastq.gz -Z --cores 4 -o ramdisk/big2.cut.fastq.gz'
Benchmark #1: cutadapt -a AGATCGGAAGAG 5000000reads.fastq.gz -Z --cores 4 -o ramdisk/big2.cut.fastq.gz
  Time (mean ± σ):      9.585 s ±  0.050 s    [User: 47.314 s, System: 4.087 s]
  Range (min … max):    9.506 s …  9.642 s    10 runs
```
Wall clock time: 9.6 sec. Compute time 51.4 sec.
There is a slight hit in wall clock and compute time compared to igzip, but much better than pigz.

This was tested with the following branch of python-isal: https://github.com/pycompression/python-isal/pull/38 . That will need to be released before this change can be used (adds a '-c' flag).

If this gets released cutadapt users who install via PyPI and use multiple cores will see a compute time decrease of ~35%. Conda and biocontainer users of cutadapt will see no additional benefit.


