### PR TITLE
Split PipedGzipReader/-Writer classes

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -590,16 +590,17 @@ def xopen(
     bzip2 and xz. If the filename is '-', standard output (mode 'w') or
     standard input (mode 'r') is returned.
 
-    The file type is determined based on the filename: .gz is gzip, .bz2 is bzip2, .xz is
-    xz/lzma and no compression assumed otherwise.
+    When writing, the file format is chosen based on the file name extension:
+    - .gz uses gzip compression
+    - .bz2 uses bzip2 compression
+    - .xz uses xz/lzma compression
+    - otherwise, no compression is used
+
+    When reading, if a file name extension is available, the format is detected
+    using it, but if not, the format is detected from the contents.
 
     mode can be: 'rt', 'rb', 'at', 'ab', 'wt', or 'wb'. Also, the 't' can be omitted,
     so instead of 'rt', 'wt' and 'at', the abbreviations 'r', 'w' and 'a' can be used.
-
-    In Python 2, the 't' and 'b' characters are ignored.
-
-    Append mode ('a', 'at', 'ab') is not available with BZ2 compression and
-    will raise an error.
 
     compresslevel is the compression level for writing to gzip files.
     This parameter is ignored for the other compression formats. If set to

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -2,7 +2,18 @@
 Open compressed files transparently.
 """
 
-__all__ = ["xopen", "PipedGzipWriter", "PipedGzipReader", "__version__"]
+__all__ = [
+    "xopen",
+    "PipedGzipReader",
+    "PipedGzipWriter",
+    "PipedIGzipReader",
+    "PipedIGzipWriter",
+    "PipedPigzReader",
+    "PipedPigzWriter",
+    "PipedPythonIsalReader",
+    "PipedPythonIsalWriter",
+    "__version__",
+]
 
 import gzip
 import sys

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -8,9 +8,16 @@ import time
 import pytest
 from pathlib import Path
 
-from xopen import xopen, PipedCompressionWriter, PipedGzipReader, \
-    PipedGzipWriter, _MAX_PIPE_SIZE, _can_read_concatenated_gz
-
+from xopen import (
+    xopen,
+    PipedCompressionWriter,
+    PipedGzipReader,
+    PipedGzipWriter,
+    PipedPigzReader,
+    PipedPigzWriter,
+    _MAX_PIPE_SIZE,
+    _can_read_concatenated_gz,
+)
 extensions = ["", ".gz", ".bz2"]
 
 try:
@@ -169,8 +176,8 @@ def test_readline_text_pipedgzipreader():
 
 
 @pytest.mark.parametrize("threads", [None, 1, 2])
-def test_pipedgzipreader_iter(threads):
-    with PipedGzipReader("tests/file.txt.gz", mode="r", threads=threads) as f:
+def test_pipedpigzpreader_iter(threads):
+    with PipedPigzReader("tests/file.txt.gz", mode="r", threads=threads) as f:
         lines = list(f)
         assert lines[0] == CONTENT_LINES[0]
 


### PR DESCRIPTION
This closes #50 by splitting a PipedPigzReader/-Writer class off from PipedGzipReader/-Writer.

I also refactored the tests a bit to ensure that all the Piped... classes are tested, not only PipedGzipReader.