### PR TITLE
Obtain coverage for full source, not only tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     coverage
 setenv = PYTHONDEVMODE = 1
 commands =
-    coverage run --concurrency=multiprocessing -m pytest --doctest-modules src/xopen/ tests/
+    coverage run --concurrency=multiprocessing -m pytest --doctest-modules --pyargs xopen tests
     coverage combine
     coverage report
     coverage xml


### PR DESCRIPTION
Since commit 8b71eb30d31b2c1e98c22409f8ab5d733988e5c2, coverage reports only included the `test_xopen.py` module, not the source of the `xopen` module.

The test fails because we had artificially inflated coverage until now.