### PR TITLE
Install isal wheels on windows too.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     package_data={"xopen": ["py.typed"]},
     extras_require={
         'dev': ['pytest'],
-        ':(sys_platform=="linux" or sys_platform=="darwin") and python_implementation != "PyPy"': ['isal>=0.5.0']
+        ':python_implementation != "PyPy"': ['isal>=0.6.0']
     },
     python_requires='>=3.6',
     classifiers=[


### PR DESCRIPTION
I enabled installation on windows for python-isal. Wheels are provided as well: https://pypi.org/project/isal/0.6.0/#files

@marcelm You may want to take a loot at the ci.yml with cibuildwheel of python-isal. I think it will be quite trivial for you to create windows and mac wheels as well for dnaio and cutadapt.