### PR TITLE
Always install isa-l on supported 64-bit systems.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,12 @@ setup(
     package_data={"xopen": ["py.typed"]},
     extras_require={
         'dev': ['pytest'],
-        # Install isa-l on 64 bit platforms. Wheels are provided.
-        ':"64" in platform.machine': ['isal>=0.9.0'],
+        # Install isa-l on 64 bit platforms. Python-isal wheels are provided for:
+        # x86_64: Linux and MacOS x86_64 platforms
+        # AMD64: Windows x86_64 platforms.
+        # aarch64: Linux ARM 64-bit platforms.
+        # Wheels are not provided for 'arm64'. The MacOS 64 bit platforms. 
+        ':platform.machine in ["x86_64","AMD64", "aarch64"]': ['isal>=0.9.0'],
     },
     python_requires='>=3.6',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
     package_data={"xopen": ["py.typed"]},
     extras_require={
         'dev': ['pytest'],
-        ':python_implementation != "PyPy"': ['isal>=0.6.1']
+        # Install isa-l on 64 bit platforms. Wheels are provided.
+        ':"64" in platform.machine': ['isal>=0.9.0'],
     },
     python_requires='>=3.6',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,9 @@ setup(
         # AMD64: Windows x86_64 platforms.
         # aarch64: Linux ARM 64-bit platforms.
         # Wheels are not provided for 'arm64'. The MacOS 64 bit platforms. 
-        ':platform.machine in ["x86_64","AMD64", "aarch64"]': ['isal>=0.9.0'],
+        ':platform.machine == "x86_64"': ['isal>=0.9.0'],
+        ':platform.machine == "AMD64"': ['isal>=0.9.0'],
+        ':platform.machine == "aarch64"': ['isal>=0.9.0'],
     },
     python_requires='>=3.6',
     classifiers=[


### PR DESCRIPTION
Pypy is now supported. Wheels are also build for aarch64.

isa-l is 64-bit only.