### PR TITLE
Add tests for no isal installation

### DIFF
--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -557,7 +557,7 @@ def test_xopen_fals_back_to_gzip_open_write_no_isal(lacking_pigz_permissions,
     tmp = tmp_path / "test.gz"
     with xopen.xopen(tmp, "wb") as f:
         f.write(b"hello")
-    assert gzip.decompress(tmp.read_bytes())== b"hello"
+    assert gzip.decompress(tmp.read_bytes()) == b"hello"
 
 
 def test_open_many_gzip_writers(tmp_path):

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -550,6 +550,16 @@ def test_xopen_falls_back_to_gzip_open_no_isal(lacking_pigz_permissions,
         assert f.readline() == CONTENT_LINES[0].encode("utf-8")
 
 
+def test_xopen_fals_back_to_gzip_open_write_no_isal(lacking_pigz_permissions,
+                                                    monkeypatch, tmp_path):
+    import xopen  # xopen local overrides xopen global variable
+    monkeypatch.setattr(xopen, "igzip", None)
+    tmp = tmp_path / "test.gz"
+    with xopen.xopen(tmp, "wb") as f:
+        f.write(b"hello")
+    assert gzip.decompress(tmp.read_bytes())== b"hello"
+
+
 def test_open_many_gzip_writers(tmp_path):
     files = []
     for i in range(1, 61):

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -145,6 +145,24 @@ def test_xopen_binary(fname):
         assert lines[1] == b'The second line.\n', fname
 
 
+def test_xopen_binary_no_isal_no_threads(fname, monkeypatch):
+    import xopen  # xopen local overrides xopen global variable
+    monkeypatch.setattr(xopen, "igzip", None)
+    with xopen.xopen(fname, 'rb', threads=0) as f:
+        lines = list(f)
+        assert len(lines) == 2
+        assert lines[1] == b'The second line.\n', fname
+
+
+def test_xopen_binary_no_isal(fname, monkeypatch):
+    import xopen  # xopen local overrides xopen global variable
+    monkeypatch.setattr(xopen, "igzip", None)
+    with xopen.xopen(fname, 'rb', threads=1) as f:
+        lines = list(f)
+        assert len(lines) == 2
+        assert lines[1] == b'The second line.\n', fname
+
+
 def test_no_context_manager_text(fname):
     f = xopen(fname, 'rt')
     lines = list(f)
@@ -419,6 +437,16 @@ def test_write_pigz_threads(tmpdir):
         assert f.read() == 'hello'
 
 
+def test_write_pigz_threads_no_isal(tmpdir, monkeypatch):
+    import xopen  # xopen local overrides xopen global variable
+    monkeypatch.setattr(xopen, "igzip", None)
+    path = str(tmpdir.join('out.gz'))
+    with xopen.xopen(path, mode='w', threads=3) as f:
+        f.write('hello')
+    with xopen.xopen(path) as f:
+        assert f.read() == 'hello'
+
+
 def test_read_gzip_no_threads():
     import gzip
     with xopen("tests/hello.gz", "rb", threads=0) as f:
@@ -429,6 +457,15 @@ def test_write_gzip_no_threads(tmpdir):
     import gzip
     path = str(tmpdir.join("out.gz"))
     with xopen(path, "wb", threads=0) as f:
+        assert isinstance(f, gzip.GzipFile), f
+
+
+def test_write_gzip_no_threads_no_isal(tmpdir, monkeypatch):
+    import xopen  # xopen local overrides xopen global variable
+    monkeypatch.setattr(xopen, "igzip", None)
+    import gzip
+    path = str(tmpdir.join("out.gz"))
+    with xopen.xopen(path, "wb", threads=0) as f:
         assert isinstance(f, gzip.GzipFile), f
 
 

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -542,6 +542,14 @@ def test_xopen_falls_back_to_gzip_open(lacking_pigz_permissions):
         assert f.readline() == CONTENT_LINES[0].encode("utf-8")
 
 
+def test_xopen_falls_back_to_gzip_open_no_isal(lacking_pigz_permissions,
+                                               monkeypatch):
+    import xopen  # xopen local overrides xopen global variable
+    monkeypatch.setattr(xopen, "igzip", None)
+    with xopen.xopen("tests/file.txt.gz", "rb") as f:
+        assert f.readline() == CONTENT_LINES[0].encode("utf-8")
+
+
 def test_open_many_gzip_writers(tmp_path):
     files = []
     for i in range(1, 61):


### PR DESCRIPTION
fixes #58 

This restores the coverage after #57 . Except for the lines after `except ImportError` when isal is imported, but these are so simple (set two variables to None) that testing is not really needed.

EDIT: https://app.codecov.io/gh/pycompression/xopen/compare/59/changes#D1L42 These lines can probably not be recovered for coverage. Unless we start testing on 32-bit systems that will never support isal. Or architectures other than x86_64 and aarch64. 