### PR TITLE
Switch to declarative configuration with setup.cfg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm"]
+requires = ["setuptools", "wheel", "setuptools_scm>=6.2"]
+
+[tool.setuptools_scm]
+write_to = "src/xopen/_version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,30 @@
+[metadata]
+name = xopen
+author = Marcel Martin et al.
+author_email = mail@marcelm.net
+url = https://github.com/pycompression/xopen/
+description = Open compressed files transparently
+long_description = file: README.rst
+license = MIT
+classifiers =
+    Development Status :: 5 - Production/Stable
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3
+
+[options]
+python_requires = >=3.6
+package_dir =
+    =src
+packages = find:
+install_requires =
+    isal>=0.9.0; platform_machine == "x86_64" or platform_machine == "AMD64" or platform_machine == "aarch64"
+
+[options.packages.find]
+where = src
+
+[options.package_data]
+* = py.typed
+
+[options.extras_require]
+dev = pytest
+

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,3 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-with open('README.rst') as f:
-    long_description = f.read()
-
-setup(
-    name='xopen',
-    use_scm_version={'write_to': 'src/xopen/_version.py'},
-    setup_requires=['setuptools_scm'],  # Support pip versions that don't know about pyproject.toml
-    author='Marcel Martin et al.',
-    author_email='mail@marcelm.net',
-    url='https://github.com/pycompression/xopen/',
-    description='Open compressed files transparently',
-    long_description=long_description,
-    license='MIT',
-    package_dir={'': 'src'},
-    packages=find_packages('src'),
-    package_data={"xopen": ["py.typed"]},
-    extras_require={
-        'dev': ['pytest'],
-        # Install isa-l on 64 bit platforms. Python-isal wheels are provided for:
-        # x86_64: Linux and MacOS x86_64 platforms
-        # AMD64: Windows x86_64 platforms.
-        # aarch64: Linux ARM 64-bit platforms.
-        # Wheels are not provided for 'arm64'. The MacOS 64 bit platforms. 
-        ':platform_machine == "x86_64"': ['isal>=0.9.0'],
-        ':platform_machine == "AMD64"': ['isal>=0.9.0'],
-        ':platform_machine == "aarch64"': ['isal>=0.9.0'],
-    },
-    python_requires='>=3.6',
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
-    ]
-)
+setup(setup_requires=["setuptools_scm"])


### PR DESCRIPTION
and update outdated syntax for specifying dependencies with environment
markers

A skeleton setup.py needs to remain to support 'pip install -e .'

See #70

Thanks @jezdez