### PR TITLE
Accomodate for /proc/sys/fs/pipe-max-size not being available due to permission errors

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -53,9 +53,9 @@ except ImportError:
     fcntl = None  # type: ignore
 
 _MAX_PIPE_SIZE_PATH = pathlib.Path("/proc/sys/fs/pipe-max-size")
-if _MAX_PIPE_SIZE_PATH.exists():
+try:
     _MAX_PIPE_SIZE = int(_MAX_PIPE_SIZE_PATH.read_text())  # type: Optional[int]
-else:
+except OSError:  # Catches file not found and permission errors. Possible other errors too.
     _MAX_PIPE_SIZE = None
 
 


### PR DESCRIPTION
I installed xopen on my phone (wanted to test something) and found that max pipe size was not available due to permission error. This fixes that issue.

@marcelm It would be nice if this lands in the next release.