### PR TITLE
Buffer compression writers

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -747,5 +747,5 @@ def xopen(
     # less. The effect is very noticable when writing small units such as lines
     # or FASTQ records.
     if isinstance(opened_file, _compression.BaseStream) and "w" in mode:
-        opened_file = io.BufferedWriter(opened_file)
+        opened_file = io.BufferedWriter(opened_file)  # type: ignore
     return opened_file

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -532,14 +532,16 @@ def test_write_no_threads(tmpdir, ext):
     klass = klasses[ext]
     path = str(tmpdir.join(f"out.{ext}"))
     with xopen(path, "wb", threads=0) as f:
-        assert isinstance(f, klass), f
+        assert isinstance(f, io.BufferedWriter)
+        if ext:
+            assert isinstance(f.raw, klass), f
 
 
 def test_write_gzip_no_threads_no_isal(tmpdir, xopen_without_igzip):
     import gzip
     path = str(tmpdir.join("out.gz"))
     with xopen_without_igzip(path, "wb", threads=0) as f:
-        assert isinstance(f, gzip.GzipFile), f
+        assert isinstance(f.raw, gzip.GzipFile), f
 
 
 def test_write_stdout():


### PR DESCRIPTION
Hi I noticed some weird performance characteristics when using single-threaded compressed writing during developing fastq filter.

These characteristics can easily be reproduced with the following script:

```Python
#! /usr/bin/env python3

import sys

import xopen

if __name__ == "__main__":
    threads = sys.argv[1]
    in_file = sys.argv[2]
    out_file = sys.argv[3]
    with open(in_file, "rb") as in_file_h:
        with xopen.xopen(out_file, mode="wb", threads=int(threads),
                         compresslevel=1) as out_file_h:
            for line in in_file_h:
                out_file_h.write(line)

```

This will default to using IGzipFile when threads=0 and use a PipedPythonIsalWriter when threads=1.

Benchmarks:
No compression for comparison:
```
Benchmark #1: python xopen_write_lines.py 0  ~/test/big2.fastq ramdisk/out.fastq
  Time (mean ± σ):      2.816 s ±  0.129 s    [User: 2.075 s, System: 0.740 s]
  Range (min … max):    2.698 s …  3.148 s    10 runs
```

Using a piped python-isal writer:
```
Benchmark #1: python xopen_write_lines.py 1  ~/test/big2.fastq ramdisk/out.fastq.gz
  Time (mean ± σ):      4.965 s ±  0.090 s    [User: 8.599 s, System: 0.846 s]
  Range (min … max):    4.873 s …  5.186 s    10 runs
```
User time + system time is roughly 9.4 seconds. 6.6 seconds more than writing to an uncompressed file. That is fair for a 1.6 GB file.

But now single threaded:
```
Benchmark #1: python xopen_write_lines.py 0  ~/test/big2.fastq ramdisk/out.fastq.gz
  Time (mean ± σ):     33.275 s ±  0.483 s    [User: 32.901 s, System: 0.369 s]
  Range (min … max):   32.671 s … 34.153 s    10 runs
```
That is a tremendous increase. This is due to GzipFile.write() being tremendously expensive. A compress action is done, but also the length and the checksum are updated. There is a lot of overhead in python calls.

By using an io.BufferedWriter, we create a buffer. And `write` is only called every 8 KB. That makes a huge difference:
```
Benchmark #1: python xopen_write_lines.py 0  ~/test/big2.fastq ramdisk/out.fastq.gz
  Time (mean ± σ):      8.822 s ±  0.235 s    [User: 8.485 s, System: 0.335 s]
  Range (min … max):    8.531 s …  9.168 s    10 runs
```
Note that this time, the single-threaded solution uses less CPU overall (but more wall clock time). This is the behavior that is expected, where multithreading generally has some overhead compared to single thread.

The change is not very invasive and should increase performance across a range of applications that write small records. Most notably cutadapt, because fastq records are  generally 335 bytes or so when using standard illumina 150bp reads.