### PR TITLE
Do not install isal automatically on aarch64

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ package_dir =
     =src
 packages = find:
 install_requires =
-    isal>=0.9.0; platform_machine == "x86_64" or platform_machine == "AMD64" or platform_machine == "aarch64"
+    isal>=0.9.0; platform_machine == "x86_64" or platform_machine == "AMD64"
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Decompressing is slower than native zlib with ISA-L.

I tested this on an aarch64 machine with ARM Cortex-A53 cores. (Allwinner A64 olimex olinuxino board). 

Compression is 2x faster. But decompression was about 30% slower. That is not a clear win. Unlike x86_64 where it decompresses 2x faster and compresses 5x faster.