### PR TITLE
Add parameter to force a format

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -704,7 +704,7 @@ def xopen(
     mode: str = "r",
     compresslevel: Optional[int] = None,
     threads: Optional[int] = None,
-    *,  # Keyword-only arguments below
+    *,
     format: Optional[str] = None,
 ) -> IO:
     """

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -703,6 +703,7 @@ def xopen(
     mode: str = "r",
     compresslevel: Optional[int] = None,
     threads: Optional[int] = None,
+    format: Optional[str] = None
 ) -> IO:
     """
     A replacement for the "open" function that can also read and write
@@ -732,6 +733,10 @@ def xopen(
     (parallel gzip) subprocess if possible. See PipedGzipWriter and PipedGzipReader.
 
     When threads = 0, no subprocess is used.
+
+    format overrides the autodetection of input and output formats. This can be
+    useful when compressed output needs to be written to a file without an
+    extension. Possible values are "gz", "xz" and "bz2".
     """
     if mode in ('r', 'w', 'a'):
         mode += 't'
@@ -742,7 +747,10 @@ def xopen(
     if filename == '-':
         return _open_stdin_or_out(mode)
 
-    detected_format = _detect_format_from_extension(filename)
+    if format not in (None, "gz", "xz", "bz2"):
+        raise ValueError(f"Format not supported: {format}. "
+                         f"Choose one of: 'gz', 'xz', 'bz2'")
+    detected_format = format or _detect_format_from_extension(filename)
     if detected_format is None and "w" not in mode:
         detected_format = _detect_format_from_content(filename)
 

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -587,8 +587,9 @@ def _open_bz2(filename, mode: str, threads: Optional[int]):
         except OSError:
             pass  # We try without threads.
 
-    # Ignore overzealous typing error from mypy.
-    # str is not an accepted mode type, it has to be Literal["rb"] etc.
+    # Ignore a TypeError that has been fixed in the typeshed.
+    # https://github.com/python/typeshed/pull/6722
+    # The ignore can be removed when a version of mypy with a synced typeshed is released.
     return bz2.open(filename, mode)  # type: ignore
 
 

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -703,7 +703,8 @@ def xopen(
     mode: str = "r",
     compresslevel: Optional[int] = None,
     threads: Optional[int] = None,
-    format: Optional[str] = None
+    *,  # Keyword-only arguments below
+    format: Optional[str] = None,
 ) -> IO:
     """
     A replacement for the "open" function that can also read and write

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -723,7 +723,7 @@ def test_valid_compression_levels(writer, level, tmpdir):
     assert gzip.decompress(Path(test_file).read_bytes()) == b"test"
 
 
-def test_format_override(tmp_path):
+def test_override_output_format(tmp_path):
     test_file = tmp_path / "test_gzip_compressed"
     with xopen(test_file, mode="wb", format="gz") as f:
         f.write(b"test")
@@ -732,7 +732,7 @@ def test_format_override(tmp_path):
     assert gzip.decompress(test_contents) == b"test"
 
 
-def test_format_override_unsupported_format(tmp_path):
+def test_override_output_format_unsupported_format(tmp_path):
     test_file = tmp_path / "test_fairy_format_compressed"
     with pytest.raises(ValueError) as error:
         xopen(test_file, mode="wb", format="fairy")

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -736,5 +736,5 @@ def test_format_override_unsupported_format(tmpdir):
     test_file = tmpdir.join("test_fairy_format_compressed")
     with pytest.raises(ValueError) as error:
         xopen(test_file, mode="wb", format="fairy")
-    assert error.match("not supported")
-    assert error.match("fairy")
+    error.match("not supported")
+    error.match("fairy")

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -721,3 +721,20 @@ def test_valid_compression_levels(writer, level, tmpdir):
     with writer(test_file, "wb", level) as handle:
         handle.write(b"test")
     assert gzip.decompress(Path(test_file).read_bytes()) == b"test"
+
+
+def test_format_override(tmpdir):
+    test_file = tmpdir.join("test_gzip_compressed")
+    with xopen(test_file, mode="wb", format="gz") as f:
+        f.write(b"test")
+    test_contents = test_file.read("rb")
+    assert test_contents.startswith(b"\x1f\x8b")  # Gzip magic
+    assert gzip.decompress(test_contents) == b"test"
+
+
+def test_format_override_unsupported_format(tmpdir):
+    test_file = tmpdir.join("test_fairy_format_compressed")
+    with pytest.raises(ValueError) as error:
+        xopen(test_file, mode="wb", format="fairy")
+    assert error.match("not supported")
+    assert error.match("fairy")

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -738,3 +738,11 @@ def test_override_output_format_unsupported_format(tmp_path):
         xopen(test_file, mode="wb", format="fairy")
     error.match("not supported")
     error.match("fairy")
+
+
+def test_override_output_format_wrong_format(tmp_path):
+    test_file = tmp_path / "not_compressed"
+    test_file.write_text("I am not compressed.")
+    with pytest.raises(OSError):  # BadGzipFile is a subclass of OSError
+        with xopen(test_file, "rt", format="gz") as opened_file:
+            opened_file.read()

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -723,17 +723,17 @@ def test_valid_compression_levels(writer, level, tmpdir):
     assert gzip.decompress(Path(test_file).read_bytes()) == b"test"
 
 
-def test_format_override(tmpdir):
-    test_file = tmpdir.join("test_gzip_compressed")
+def test_format_override(tmp_path):
+    test_file = tmp_path / "test_gzip_compressed"
     with xopen(test_file, mode="wb", format="gz") as f:
         f.write(b"test")
-    test_contents = test_file.read("rb")
+    test_contents = test_file.read_bytes()
     assert test_contents.startswith(b"\x1f\x8b")  # Gzip magic
     assert gzip.decompress(test_contents) == b"test"
 
 
-def test_format_override_unsupported_format(tmpdir):
-    test_file = tmpdir.join("test_fairy_format_compressed")
+def test_format_override_unsupported_format(tmp_path):
+    test_file = tmp_path / "test_fairy_format_compressed"
     with pytest.raises(ValueError) as error:
         xopen(test_file, mode="wb", format="fairy")
     error.match("not supported")


### PR DESCRIPTION
I am currently working on a FASTQ filtering program for inclusion into [galaxy](https://galaxyproject.org/). 

One quirk of galaxy is that all datasets are written to `.dat` files. These `.dat` files are allowed to contain compressed data, as the metadata is stored in galaxy as well which specifies the exact format.

This means that fastq-filter which uses xopen will always default to `None` since `.dat` is not a known format. This results in people reaching their disk quota much faster as uncompressed files are about three times bigger.

I could of course workaround this by using `igzip.open` instead of xopen, but that would also lose me the flexibility of xopen in terms of:
- Threaded support
- Compression level automatically selecting the correct program (igzip vs pigz)

And it would require extra code to implement. Adding a simple `format` parameter to xopen was trivial, does not break backwards compatibility and will automatically choose the fastest way to write said format.