### PR TITLE
Test on Python 3.10 and enable EncodeWarning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy-3.7"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
         include:
         - os: macos-latest
           python-version: 3.7

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -437,7 +437,7 @@ class TookTooLongError(Exception):
     pass
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.timeout(5)
 @pytest.mark.parametrize("extension", [".gz", ".bz2"])
 def test_truncated_file(extension, create_truncated_file):
     truncated_file = create_truncated_file(extension)
@@ -447,7 +447,7 @@ def test_truncated_file(extension, create_truncated_file):
         f.close()  # pragma: no cover
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.timeout(5)
 @pytest.mark.parametrize("extension", [".gz", ".bz2"])
 def test_truncated_iter(extension, create_truncated_file):
     truncated_file = create_truncated_file(extension)
@@ -458,7 +458,7 @@ def test_truncated_iter(extension, create_truncated_file):
         f.close()  # pragma: no cover
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.timeout(5)
 @pytest.mark.parametrize("extension", [".gz", ".bz2"])
 def test_truncated_with(extension, create_truncated_file):
     truncated_file = create_truncated_file(extension)
@@ -467,7 +467,7 @@ def test_truncated_with(extension, create_truncated_file):
             f.read()
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.timeout(5)
 @pytest.mark.parametrize("extension", [".gz", ".bz2"])
 def test_truncated_iter_with(extension, create_truncated_file):
     truncated_file = create_truncated_file(extension)

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 [tox]
-envlist = flake8,mypy,py36,py37,py38,py39,pypy3
+envlist = flake8,mypy,py36,py37,py38,py39,py310,pypy3
 
 [testenv]
 deps =
     pytest
     pytest-timeout
     coverage
-setenv = PYTHONDEVMODE = 1
+setenv =
+    PYTHONDEVMODE = 1
+    PYTHONWARNDEFAULTENCODING = 1
 commands =
     coverage run --branch --source=xopen,tests -m pytest -v --doctest-modules tests
     coverage report


### PR DESCRIPTION
As mentioned in #81, `encoding=` should always be explicitly passed. This enables `PYTHONWARNDEFAULTENCODING`, which warns if the default encoding is used. This is only available on Python 3.10, so also enable tests on Python 3.10.