### PR TITLE
Add seek() and tell() to PipedCompressionReader

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -423,6 +423,12 @@ class PipedCompressionReader(Closing):
     def seekable(self) -> bool:
         return self._file.seekable()
 
+    def tell(self) -> int:
+        return self._file.tell()
+
+    def seek(self, offset, whence=0) -> int:
+        return self._file.seek(offset, whence)
+
     def peek(self, n: int = None):
         if hasattr(self._file, "peek"):
             return self._file.peek(n)  # type: ignore

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -692,6 +692,17 @@ def test_piped_compression_reader_peek_binary(reader):
         assert read_h.peek(1).startswith(b"T")
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="seeking only works on Windows for now")
+def test_piped_compression_reader_seek_and_tell(reader):
+    opener, extension = reader
+    filegz = Path(__file__).parent / f"file.txt{extension}"
+    with opener(filegz, "rb") as f:
+        original_position = f.tell()
+        assert f.read(4) == b"Test"
+        f.seek(original_position)
+        assert f.read(8) == b"Testing,"
+
+
 @pytest.mark.parametrize("mode", ["r", "rt"])
 def test_piped_compression_reader_peek_text(reader, mode):
     opener, extension = reader


### PR DESCRIPTION
These are just passed along to the underlying `_file` (the process` stdout).

This is needed by dnaio on Windows because `sys.stdin.buffer` on Windows is seekable, which triggers a different code path in `dnaio.singleend._detect_format_from_content` that relies on `seek()` and `tell()`.

Also, since `PipedCompressionReader.seekable()` already exists, we should also really have `seek()`.

~~Tests fail because coverage drops. I’ll see whether I find the energy to add some.~~ Test added