### PR TITLE
Use Black

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7]
-        toxenv: [flake8, mypy]
+        toxenv: [black, flake8, mypy]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 21.12b0
+    hooks:
+    -   id: black

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 .. image:: https://github.com/pycompression/xopen/workflows/CI/badge.svg
   :target: https://github.com/pycompression/xopen
-  :alt: 
-  
+  :alt:
+
 .. image:: https://img.shields.io/pypi/v/xopen.svg?branch=master
   :target: https://pypi.python.org/pypi/xopen
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,12 @@ deps =
     coverage
     isal
 
+[testenv:black]
+basepython = python3.7
+deps = black==21.12b0
+skip_install = true
+commands = black --check src/ tests/
+
 [testenv:flake8]
 basepython = python3.7
 deps = flake8


### PR DESCRIPTION
@rhpvorderman I’ve started to use Black in some of my projects and xopen would be another good candidate where it would make sense to use it. Although I don’t agree with all choices that Black makes, it is so much nicer not to have to talk about code formatting during PRs. (I saw some (minor) formatting issues in some of the recent PRs, but was already planning this PR, so I didn’t mention it.)

With this change, black-like formatting would be enforced during CI. To not have to remember to run `black` before each commit, pre commit hooks can be used, and it’s easiest to manage these with [https://pre-commit.com/](pre-commit). I added a pre-commit configuration file. To use it, run `pipx install pre-commit` and then `pre-commit install` in the repo.