### PR TITLE
Use a bigger output buffer for writing to gzip and standard files

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -35,6 +35,7 @@ from typing import Optional, Union, TextIO, AnyStr, IO, List, Set
 
 from ._version import version as __version__
 
+# 128K buffer size also used by cat, pigz etc. It is faster than the 8K default.
 BUFFER_SIZE = max(io.DEFAULT_BUFFER_SIZE, 128 * 1024)
 
 
@@ -988,9 +989,7 @@ def xopen(  # noqa: C901  # The function is complex, but readable.
         isinstance(opened_file, (gzip.GzipFile, bz2.BZ2File, lzma.LZMAFile))
         and "w" in mode
     ):
-        # 128K buffer size also used by cat, pigz etc. It is faster than
-        # the 8K default.
         opened_file = io.BufferedWriter(
-            opened_file, buffer_size=128 * 1024  # type: ignore
+            opened_file, buffer_size=BUFFER_SIZE  # type: ignore
         )
     return opened_file

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -35,6 +35,8 @@ from typing import Optional, Union, TextIO, AnyStr, IO, List, Set
 
 from ._version import version as __version__
 
+BUFFER_SIZE = max(io.DEFAULT_BUFFER_SIZE, 128 * 1024)
+
 
 try:
     from isal import igzip, isal_zlib  # type: ignore
@@ -975,7 +977,7 @@ def xopen(  # noqa: C901  # The function is complex, but readable.
     elif detected_format == "bz2":
         opened_file = _open_bz2(filename, mode, threads, **text_mode_kwargs)
     else:
-        opened_file = open(filename, mode, **text_mode_kwargs)
+        opened_file = open(filename, mode, **text_mode_kwargs, buffering=BUFFER_SIZE)
 
     # The "write" method for GzipFile is very costly. Lots of python calls are
     # made. To a lesser extent this is true for LzmaFile and BZ2File. By

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -986,5 +986,9 @@ def xopen(  # noqa: C901  # The function is complex, but readable.
         isinstance(opened_file, (gzip.GzipFile, bz2.BZ2File, lzma.LZMAFile))
         and "w" in mode
     ):
-        opened_file = io.BufferedWriter(opened_file)  # type: ignore
+        # 128K buffer size also used by cat, pigz etc. It is faster than
+        # the 8K default.
+        opened_file = io.BufferedWriter(
+            opened_file, buffer_size=128 * 1024  # type: ignore
+        )
     return opened_file


### PR DESCRIPTION
Before:
```
Benchmark #1: python dnaio_read_and_write.py ~/test/big2.fastq ramdisk/output.fastq.gz
  Time (mean ± σ):      7.585 s ±  0.050 s    [User: 7.306 s, System: 0.278 s]
  Range (min … max):    7.512 s …  7.678 s    10 runs
```

After
```
Benchmark #1: python dnaio_read_and_write.py ~/test/big2.fastq ramdisk/output.fastq.gz
  Time (mean ± σ):      7.270 s ±  0.064 s    [User: 6.989 s, System: 0.279 s]
  Range (min … max):    7.129 s …  7.351 s    10 runs
```
Reading and writing dnaio without gzip is about 2 seconds. So the gzip compression time goes from 5.6 to 5.3. That is not too shabby. 