### PR TITLE
Only use a bigger buffer size for writing files

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -978,7 +978,10 @@ def xopen(  # noqa: C901  # The function is complex, but readable.
     elif detected_format == "bz2":
         opened_file = _open_bz2(filename, mode, threads, **text_mode_kwargs)
     else:
-        opened_file = open(filename, mode, **text_mode_kwargs, buffering=BUFFER_SIZE)
+        # The python default seems the fastest for reading, while using a
+        # bigger buffer size for writing improves performance.
+        bufsize = -1 if "r" in mode else BUFFER_SIZE
+        opened_file = open(filename, mode, **text_mode_kwargs, buffering=bufsize)
 
     # The "write" method for GzipFile is very costly. Lots of python calls are
     # made. To a lesser extent this is true for LzmaFile and BZ2File. By


### PR DESCRIPTION
I noticed my benchmarking was incomplete, and that I only benchmarked reading and writing.

It seems that when reading a 1.6GB file, using a 128K buffer is consistently 30ms slower than using the default buffer size. 

When writing however, there is a big leap in performance. This PR corrects the previous by only using a bigger buffer for writing.

I think a new release can be made after this, but on the other hand it is maybe best to postpone this for say, a few weeks and see if any other issues arise when using xopen. (Given the first Windows release was put out recently, that is not an unlikely scenario, since we do not use it on that platform).