### PR TITLE
Do not change default buffersize for builtin open

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -978,10 +978,7 @@ def xopen(  # noqa: C901  # The function is complex, but readable.
     elif detected_format == "bz2":
         opened_file = _open_bz2(filename, mode, threads, **text_mode_kwargs)
     else:
-        # The python default seems the fastest for reading, while using a
-        # bigger buffer size for writing improves performance.
-        bufsize = -1 if "r" in mode else BUFFER_SIZE
-        opened_file = open(filename, mode, **text_mode_kwargs, buffering=bufsize)
+        opened_file = open(filename, mode, **text_mode_kwargs)
 
     # The "write" method for GzipFile is very costly. Lots of python calls are
     # made. To a lesser extent this is true for LzmaFile and BZ2File. By


### PR DESCRIPTION
I have recently found that having a small buffersize is most beneficial when writing large chunks. A larger buffersize is more beneficial when writing lots of small chunks. Buffersize is therefore application specific and the default of 8K seems to work best.

For dnaio it seems beneficial if the output buffer is 128K instead of 8K (small chunks) but when I tested `htspy` on writing uncompressed BAM (64K max chunks) it turned out to be slower. 
It is best to leave it to the application to determine this and otherwise choose the Python builtin default.