### PR TITLE
Write reproducible gzip files in most cases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Python’s built-in ``gzip.open`` is used.
 
 When writing a gzip file (with any of the supported methods), it is written
 without timestamp and without the name of the original file (this corresponds
-to the ``gzip -n`` command-line option). Since `igzip adjusts its algorithm depending
+to the ``gzip --no-name`` command-line option). Since `igzip adjusts its algorithm depending
 on the CPU architecture <https://github.com/intel/isa-l/issues/140#issuecomment-634877966>`_,
 reproducible output is achieved only between runs on the same machine.
 
@@ -85,7 +85,7 @@ development version
 ~~~~~~~~~~~~~~~~~~~
 
 * Issue #94: When writing gzip files, the timestamp and name of the original
-  file is omitted (equivalent to using ``gzip -n`` on the command line).
+  file is omitted (equivalent to using ``gzip --no-name`` on the command line).
   This allows files to be written in a reproducible manner.
   (The bzip2 and xz compression methods do not store this information in the
   header and are therefore already reproducible.)

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Python’s built-in ``gzip.open`` is used.
 
 When writing a gzip file (with any of the supported methods), it is written
 without timestamp and without the name of the original file (this corresponds
-to the ``gzip --no-name`` command-line option). Since `igzip adjusts its algorithm depending
+to the ``gzip --no-name`` (or ``-n``) command-line option). Since `igzip adjusts its algorithm depending
 on the CPU architecture <https://github.com/intel/isa-l/issues/140#issuecomment-634877966>`_,
 reproducible output is achieved only between runs on the same machine.
 
@@ -85,8 +85,8 @@ development version
 ~~~~~~~~~~~~~~~~~~~
 
 * Issue #94: When writing gzip files, the timestamp and name of the original
-  file is omitted (equivalent to using ``gzip --no-name`` on the command line).
-  This allows files to be written in a reproducible manner.
+  file is omitted (equivalent to using ``gzip --no-name`` (or ``-n``) on the
+  command line). This allows files to be written in a reproducible manner.
   (The bzip2 and xz compression methods do not store this information in the
   header and are therefore already reproducible.)
 

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,15 @@ and avoid using an external process::
 Changes
 -------
 
+development version
+~~~~~~~~~~~~~~~~~~~
+
+* Issue #94: When writing gzip files, the timestamp and name of the original
+  file is omitted (equivalent to using ``gzip -n`` on the command line).
+  This allows files to be written in a reproducible manner.
+  (The bzip2 and xz compression methods do not store this information in the
+  header and are therefore already reproducible.)
+
 v1.5.0 (2022-03-23)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,12 @@ Neither ``igzip`` nor ``python-isal`` support compression levels
 greater 3, so if no external tool is available or ``threads`` has been set to 0,
 Python’s built-in ``gzip.open`` is used.
 
+When writing a gzip file (with any of the supported methods), it is written
+without timestamp and without the name of the original file (this corresponds
+to the ``gzip -n`` command-line option). Since `igzip adjusts its algorithm depending
+on the CPU architecture <https://github.com/intel/isa-l/issues/140#issuecomment-634877966>`_,
+reproducible output is achieved only between runs on the same machine.
+
 For xz files, a pipe to the ``xz`` program is used because it has built-in support for multithreaded compression.
 
 For bz2 files, `pbzip2 (parallel bzip2) <http://compression.ca/pbzip2/>`_ is used.

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ package_dir =
     =src
 packages = find:
 install_requires =
-    isal>=0.9.0; platform.python_implementation == 'CPython' and (platform.machine == "x86_64" or platform.machine == "AMD64")
+    isal>=1.0.0; platform.python_implementation == 'CPython' and (platform.machine == "x86_64" or platform.machine == "AMD64")
 
 [options.packages.find]
 where = src

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -882,7 +882,7 @@ def _open_xz(
 def _open_external_gzip_reader(
     filename, mode, compresslevel, threads, **text_mode_kwargs
 ):
-    assert "r" in mode
+    assert mode in ("rt", "rb")
     try:
         return PipedIGzipReader(filename, mode, **text_mode_kwargs)
     except (OSError, ValueError):
@@ -900,7 +900,7 @@ def _open_external_gzip_reader(
 def _open_external_gzip_writer(
     filename, mode, compresslevel, threads, **text_mode_kwargs
 ):
-    assert "r" not in mode
+    assert mode in ("wt", "wb", "at", "ab")
     try:
         return PipedIGzipWriter(filename, mode, compresslevel, **text_mode_kwargs)
     except (OSError, ValueError):
@@ -922,6 +922,7 @@ def _open_external_gzip_writer(
 
 
 def _open_gz(filename, mode: str, compresslevel, threads, **text_mode_kwargs):
+    assert mode in ("rt", "rb", "wt", "wb", "at", "ab")
     if threads != 0:
         try:
             if "r" in mode:
@@ -942,7 +943,7 @@ def _open_gz(filename, mode: str, compresslevel, threads, **text_mode_kwargs):
 
     g = _open_reproducible_gzip(
         filename,
-        mode=mode.replace("t", "").replace("b", "") + "b",
+        mode=mode[0] + "b",
         compresslevel=compresslevel,
     )
     if "t" in mode:
@@ -956,7 +957,7 @@ def _open_reproducible_gzip(filename, mode, compresslevel):
     that has neither mtime nor the file name in the header
     (equivalent to gzip --no-name)
     """
-    assert "b" in mode
+    assert mode in ("rb", "wb", "ab")
     # Neither gzip.open nor igzip.open have an mtime option, and they will
     # always write the file name, so we need to open the file separately
     # and pass it to gzip.GzipFile/igzip.IGzipFile.
@@ -988,7 +989,7 @@ def _open_reproducible_gzip(filename, mode, compresslevel):
         )
     # When (I)GzipFile is created with a fileobj instead of a filename,
     # the passed file object is not closed when (I)GzipFile.close()
-    # is called. With this, we can force it to do so.
+    # is called. This forces it to be closed.
     gzip_file.myfileobj = binary_file
     return gzip_file
 

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -508,7 +508,7 @@ class PipedGzipWriter(PipedCompressionWriter):
             raise ValueError("compresslevel must be between 1 and 9")
         super().__init__(
             path,
-            ["gzip"],
+            ["gzip", "-n"],
             mode,
             compresslevel,
             None,

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -821,7 +821,7 @@ class PipedPythonIsalWriter(PipedCompressionWriter):
             raise ValueError("compresslevel must be between 0 and 3")
         super().__init__(
             path,
-            [sys.executable, "-m", "isal.igzip"],
+            [sys.executable, "-m", "isal.igzip", "-n"],
             mode,
             compresslevel,
             encoding=encoding,

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -508,7 +508,7 @@ class PipedGzipWriter(PipedCompressionWriter):
             raise ValueError("compresslevel must be between 1 and 9")
         super().__init__(
             path,
-            ["gzip", "-n"],
+            ["gzip", "--no-name"],
             mode,
             compresslevel,
             None,
@@ -583,7 +583,7 @@ class PipedPigzWriter(PipedCompressionWriter):
             raise ValueError("compresslevel must be between 0 and 9 or 11")
         super().__init__(
             path,
-            ["pigz", "-n"],
+            ["pigz", "--no-name"],
             mode,
             compresslevel,
             "-p",
@@ -783,7 +783,7 @@ class PipedIGzipWriter(PipedCompressionWriter):
             raise ValueError("compresslevel must be between 0 and 3")
         super().__init__(
             path,
-            ["igzip", "-n"],
+            ["igzip", "--no-name"],
             mode,
             compresslevel,
             encoding=encoding,
@@ -821,7 +821,7 @@ class PipedPythonIsalWriter(PipedCompressionWriter):
             raise ValueError("compresslevel must be between 0 and 3")
         super().__init__(
             path,
-            [sys.executable, "-m", "isal.igzip", "-n"],
+            [sys.executable, "-m", "isal.igzip", "--no-name"],
             mode,
             compresslevel,
             encoding=encoding,
@@ -954,7 +954,7 @@ def _open_reproducible_gzip(filename, mode, compresslevel):
     """
     Open a gzip file for writing (without external processes)
     that has neither mtime nor the file name in the header
-    (equivalent to gzip -n)
+    (equivalent to gzip --no-name)
     """
     assert "b" in mode
     # Neither gzip.open nor igzip.open have an mtime option, and they will

--- a/tests/test_piped.py
+++ b/tests/test_piped.py
@@ -343,5 +343,5 @@ def test_reproducible_gzip_compression(gzip_writer, tmp_path):
         f.write(b"hello")
 
     data = path.read_bytes()
-    assert (data[3] & 8) == 0, "gzip header contains file name"
+    assert (data[3] & gzip.FNAME) == 0, "gzip header contains file name"
     assert data[4:8] == b"\0\0\0\0", "gzip header contains mtime"

--- a/tests/test_piped.py
+++ b/tests/test_piped.py
@@ -334,3 +334,14 @@ def test_compression_writer_unusual_encoding(tmp_path):
     ) as f:
         f.write("Hello")
     assert (tmp_path / "out.txt").read_bytes() == b"H\0e\0l\0l\0o\0"
+
+
+def test_reproducible_gzip_compression(gzip_writer, tmp_path):
+    path = tmp_path / "file.gz"
+    with gzip_writer(path, mode="wb") as f:
+        print(f)
+        f.write(b"hello")
+
+    data = path.read_bytes()
+    assert (data[3] & 8) == 0, "gzip header contains file name"
+    assert data[4:8] == b"\0\0\0\0", "gzip header contains mtime"

--- a/tests/test_piped.py
+++ b/tests/test_piped.py
@@ -339,7 +339,6 @@ def test_compression_writer_unusual_encoding(tmp_path):
 def test_reproducible_gzip_compression(gzip_writer, tmp_path):
     path = tmp_path / "file.gz"
     with gzip_writer(path, mode="wb") as f:
-        print(f)
         f.write(b"hello")
 
     data = path.read_bytes()

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -94,13 +94,14 @@ def test_binary(fname):
         assert lines[1] == b"The second line.\n", fname
 
 
+@pytest.mark.parametrize("mode", ["b", "", "t"])
 @pytest.mark.parametrize("threads", [None, 0])
-def test_roundtrip(ext, tmp_path, threads):
+def test_roundtrip(ext, tmp_path, threads, mode):
     path = tmp_path / f"file{ext}"
-    data = b"Hello"
-    with xopen(path, "wb", threads=threads) as f:
+    data = b"Hello" if mode == "b" else "Hello"
+    with xopen(path, "w" + mode, threads=threads) as f:
         f.write(data)
-    with xopen(path, "rb", threads=threads) as f:
+    with xopen(path, "r" + mode, threads=threads) as f:
         assert f.read() == data
 
 

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -499,3 +499,14 @@ def test_text_encoding_errors(opener, extension, tmp_path):
     with opener(path, "rt", encoding="ascii", errors="replace") as f:
         result = f.read()
     assert result == "E�n ree\nTwee ree�n\n"
+
+
+@pytest.mark.parametrize("compresslevel", [1, 6])
+def test_gzip_compression_is_reproducible_without_piping(tmp_path, compresslevel):
+    # compresslevel 1 should give us igzip and 6 should give us regular gzip
+    path = tmp_path / "test.gz"
+    with xopen(path, mode="wb", compresslevel=compresslevel, threads=0) as f:
+        f.write(b"hello")
+    data = path.read_bytes()
+    assert (data[3] & 8) == 0, "gzip header contains file name"
+    assert data[4:8] == b"\0\0\0\0", "gzip header contains mtime"

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -94,6 +94,16 @@ def test_binary(fname):
         assert lines[1] == b"The second line.\n", fname
 
 
+@pytest.mark.parametrize("threads", [None, 0])
+def test_roundtrip(ext, tmp_path, threads):
+    path = tmp_path / f"file{ext}"
+    data = b"Hello"
+    with xopen(path, "wb", threads=threads) as f:
+        f.write(data)
+    with xopen(path, "rb", threads=threads) as f:
+        assert f.read() == data
+
+
 def test_binary_no_isal_no_threads(fname, xopen_without_igzip):
     with xopen_without_igzip(fname, "rb", threads=0) as f:
         lines = list(f)

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -508,5 +508,5 @@ def test_gzip_compression_is_reproducible_without_piping(tmp_path, compresslevel
     with xopen(path, mode="wb", compresslevel=compresslevel, threads=0) as f:
         f.write(b"hello")
     data = path.read_bytes()
-    assert (data[3] & 8) == 0, "gzip header contains file name"
+    assert (data[3] & gzip.FNAME) == 0, "gzip header contains file name"
     assert data[4:8] == b"\0\0\0\0", "gzip header contains mtime"


### PR DESCRIPTION
This
* enables `-n` for the external gzip processes except `python -m isal.igzip`, which doesn’t support it, yet.
* sets the equivalent options for `gzip.open` and `igzip.open` (which had to be replaced with `gzip.GzipFile` and `igzip.IGzipFile`

The test failure is due to `PipedPythonIsalWriter`.

To Do:
* [x] Add changelog entry