### PR TITLE
Make sure isal is only installed on CPython platforms

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ package_dir =
     =src
 packages = find:
 install_requires =
-    isal>=0.9.0; platform_machine == "x86_64" or platform_machine == "AMD64"
+    isal>=0.9.0; platform.python_implementation == 'CPython' and (platform.machine == "x86_64" or platform.machine == "AMD64")
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
PyPy will no longer be supported from version 1.0 onwards in python-isal.

PyPy + isal is slower than CPython + zlib, so if the PyPy users want extra compression speed it is better for them to move to a better version of Python first. 