### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
         include:
         - os: macos-latest
           python-version: 3.7

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ tool <https://cutadapt.readthedocs.io/>`_ that is used in bioinformatics to
 manipulate sequencing data. It has been in successful use within that software
 for a few years.
 
-``xopen`` is compatible with Python versions 3.6 and later.
+``xopen`` is compatible with Python versions 3.7 and later.
 
 
 Usage
@@ -98,6 +98,11 @@ If you also want to open S3 files, you may want to use that module instead.
 
 Changes
 -------
+
+development version
+~~~~~~~~~~~~~~~~~~~
+
+* Dropped Python 3.6 support
 
 v1.4.0
 ~~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 package_dir =
     =src
 packages = find:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,mypy,py36,py37,py38,py39,py310,pypy3
+envlist = flake8,mypy,py37,py38,py39,py310,pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.6 is end-of-life and there have recently been new releases of
Python 3.7+ that fix security issues:
https://discuss.python.org/t/14353

Python 3.6 did not get these fixes, so it seems a good idea to stop using
and/or supporting it.