### PR TITLE
Bump Black version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
 
 [testenv:black]
 basepython = python3.7
-deps = black==22.1.0
+deps = black==22.3.0
 skip_install = true
 commands = black --check src/ tests/
 


### PR DESCRIPTION
This fixes: "ImportError: cannot import name '_unicodefun' from 'click'"