### PR TITLE
Fix all EncodingWarnings

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1051,14 +1051,14 @@ def xopen(  # noqa: C901  # The function is complex, but readable.
     if mode not in ("rt", "rb", "wt", "wb", "at", "ab"):
         raise ValueError("Mode '{}' not supported".format(mode))
     filename = os.fspath(filename)
-    if filename == "-":
-        return _open_stdin_or_out(mode)
 
     if "b" in mode:
         # Do not pass encoding etc. in binary mode as this raises errors.
         text_mode_kwargs = dict()
     else:
         text_mode_kwargs = dict(encoding=encoding, errors=errors, newline=newline)
+    if filename == "-":
+        return _open_stdin_or_out(mode, **text_mode_kwargs)
 
     if format not in (None, "gz", "xz", "bz2"):
         raise ValueError(

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -60,7 +60,9 @@ except ImportError:
 
 _MAX_PIPE_SIZE_PATH = pathlib.Path("/proc/sys/fs/pipe-max-size")
 try:
-    _MAX_PIPE_SIZE = int(_MAX_PIPE_SIZE_PATH.read_text())  # type: Optional[int]
+    _MAX_PIPE_SIZE = int(
+        _MAX_PIPE_SIZE_PATH.read_text(encoding="ascii")
+    )  # type: Optional[int]
 except OSError:  # Catches file not found and permission errors. Possible other errors too.
     _MAX_PIPE_SIZE = None
 

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -189,7 +189,7 @@ class PipedCompressionWriter(Closing):
             )
 
         # TODO use a context manager
-        self.outfile = open(path, mode)
+        self.outfile = open(path, mode[0] + "b")
         self.closed: bool = False
         self.name: str = str(os.fspath(path))
         self._mode: str = mode

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def create_large_file(tmp_path):
 def create_truncated_file(create_large_file):
     def _create_truncated_file(extension):
         large_file = create_large_file(extension)
-        with open(large_file, "a") as f:
+        with open(large_file, "a", encoding="ascii") as f:
             f.truncate(os.stat(large_file).st_size - 10)
         return large_file
 

--- a/tests/test_piped.py
+++ b/tests/test_piped.py
@@ -148,7 +148,7 @@ def test_reader_readinto(reader):
 def test_reader_textiowrapper(reader):
     opener, extension = reader
     with opener(TEST_DIR / f"file.txt{extension}", "rb") as f:
-        wrapped = io.TextIOWrapper(f)
+        wrapped = io.TextIOWrapper(f, encoding="utf-8")
         assert wrapped.read() == CONTENT
 
 
@@ -323,3 +323,14 @@ def test_valid_compression_levels(writer, level, tmp_path):
     with writer(path, "wb", level) as handle:
         handle.write(b"test")
     assert gzip.decompress(path.read_bytes()) == b"test"
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="cat is not available on Windows"
+)
+def test_compression_writer_unusual_encoding(tmp_path):
+    with PipedCompressionWriter(
+        tmp_path / "out.txt", program_args=["cat"], mode="wt", encoding="utf-16-le"
+    ) as f:
+        f.write("Hello")
+    assert (tmp_path / "out.txt").read_bytes() == b"H\0e\0l\0l\0o\0"

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -191,7 +191,7 @@ def test_partial_iteration_closes_correctly(extension, create_large_file):
             self.file = xopen(file, "rb")
 
         def __iter__(self):
-            wrapper = io.TextIOWrapper(self.file)
+            wrapper = io.TextIOWrapper(self.file, encoding="utf-8")
             yield from wrapper
 
     large_file = create_large_file(extension)
@@ -463,7 +463,7 @@ def test_override_output_format_unsupported_format(tmp_path):
 
 def test_override_output_format_wrong_format(tmp_path):
     path = tmp_path / "not_compressed"
-    path.write_text("I am not compressed.")
+    path.write_text("I am not compressed.", encoding="utf-8")
     with pytest.raises(OSError):  # BadGzipFile is a subclass of OSError
         with xopen(path, "rt", format="gz") as opened_file:
             opened_file.read()


### PR DESCRIPTION
We run the tests with `PYTHONWARNDEFAULTENCODING=1`, which produces a couple of warnings in Python 3.10 (see [PEP 597](https://peps.python.org/pep-0597/)). This PR adds some encoding arguments to avoid those warnings. It also fixes an error where we were ignoring the encoding when opening stdout/stderr (with `"-"` specified as input or output file name).

The added `test_compression_writer_unusual_encoding` is just because I needed to convince myself that `PipedCompressionWriter` works correctly even for somewhat nonstandard encodings (it does, even without the changes in this PR).