### PR TITLE
Remove the special "isal" test environment from tox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,24 +28,23 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
+        optional-deps: [true]
         include:
         - os: macos-latest
           python-version: 3.7
+          optional-deps: true
         - os: ubuntu-20.04
           python-version: 3.7
-          with-isal: true
+          optional-deps: false
         - os: windows-latest
           python-version: 3.7
     steps:
-    - name: Install pigz and pbzip2 MacOS
-      if: runner.os == 'macOS'
-      run: brew install pigz pbzip2
-    - name: Install pigz and pbzip2 Linux
-      if: runner.os == 'Linux'
-      run: sudo apt-get install pigz pbzip2
-    - name: Install isal
-      if: matrix.with-isal && runner.os == 'Linux'
-      run: sudo apt-get install isal libisal-dev
+    - name: Install optional tools macOS
+      if: runner.os == 'macOS' && matrix.optional-deps
+      run: brew install pigz pbzip2 isa-l
+    - name: Install optional tools Linux
+      if: runner.os == 'Linux' && matrix.optional-deps
+      run: sudo apt-get install pigz pbzip2 isal
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
@@ -57,10 +56,6 @@ jobs:
       run: python -m pip install tox
     - name: Test
       run: tox -e py
-      if: matrix.with-isal == null
-    - name: Test with isal
-      run: tox -e isal
-      if: matrix.with-isal
     - name: Upload coverage report
       uses: codecov/codecov-action@v1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel", "setuptools_scm>=6.2"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "src/xopen/_version.py"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = flake8,mypy,py37,py38,py39,py310,pypy3
+isolated_build = True
 
 [testenv]
 deps =
@@ -14,13 +15,6 @@ commands =
     coverage report
     coverage xml
     coverage html
-
-[testenv:isal]
-deps =
-    pytest
-    pytest-timeout
-    coverage
-    isal
 
 [testenv:black]
 basepython = python3.7


### PR DESCRIPTION
This changes tox.ini to always build using pyproject.toml (`isolated_build = true`), which is more accurate as it also installs the dependencies as `pip install` would do.

Since this also installs all the Python-level dependencies including `isal`, the special tox environment named "isal" loses its meaning and is removed.

Instead, this configures the GitHub Actions workflow to test the library once with all external command-line tools installed and once without. (At least without those that are not pre-installed in the GitHub runner.)

Let’s see whether this changes the test coverage.