### PR TITLE
Increase test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
     - name: Install optional tools Linux
       if: runner.os == 'Linux' && matrix.optional-deps
       run: sudo apt-get install pigz pbzip2 isal
+    - name: Remove xz
+      if: runner.os == 'Linux' && !matrix.optional-deps
+      run: while which xz; do sudo rm $(which xz); done
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -88,12 +88,8 @@ def _available_cpu_count() -> int:
                 return res
     except OSError:
         pass
-    try:
-        import multiprocessing
-
-        return multiprocessing.cpu_count()
-    except (ImportError, NotImplementedError):
-        return 1
+    count = os.cpu_count()
+    return 1 if count is None else count
 
 
 def _set_pipe_size_to_max(fd: int) -> None:

--- a/tests/test_piped.py
+++ b/tests/test_piped.py
@@ -196,10 +196,16 @@ def test_reader_close(mode, reader, create_large_file):
     # The subprocess should be properly terminated now
 
 
-def test_invalid_compression_level_writers(gzip_writer, tmp_path):
-    # Currently only gzip writers handle compression levels
+def test_invalid_compression_level_gzip(gzip_writer, tmp_path):
     with pytest.raises(ValueError) as e:
         with gzip_writer(tmp_path / "out.gz", mode="w", compresslevel=17) as f:
+            f.write("hello")  # pragma: no cover
+    assert "compresslevel must be" in e.value.args[0]
+
+
+def test_invalid_compression_level_xz(tmp_path):
+    with pytest.raises(ValueError) as e:
+        with xopen(tmp_path / "out.xz", mode="w", compresslevel=10) as f:
             f.write("hello")  # pragma: no cover
     assert "compresslevel must be" in e.value.args[0]
 

--- a/tests/test_piped.py
+++ b/tests/test_piped.py
@@ -223,7 +223,7 @@ def test_readers_read(reader):
 def test_concatenated_gzip_function():
     assert _can_read_concatenated_gz("gzip") is True
     assert _can_read_concatenated_gz("pigz") is True
-    assert _can_read_concatenated_gz("xz") is False
+    assert _can_read_concatenated_gz("cat") is False
 
 
 @pytest.mark.skipif(

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -521,3 +521,8 @@ def test_gzip_compression_is_reproducible_without_piping(tmp_path, compresslevel
     data = path.read_bytes()
     assert (data[3] & gzip.FNAME) == 0, "gzip header contains file name"
     assert data[4:8] == b"\0\0\0\0", "gzip header contains mtime"
+
+
+def test_read_devnull():
+    with xopen(os.devnull):
+        pass


### PR DESCRIPTION
A couple of commits that improve coverage a little bit.

In the "Run tests also without xz binary being available" commit, I wanted to get rid of the yellow color in line 94 in 
https://app.codecov.io/gh/pycompression/xopen/blob/09efe472ea488f38113fff8527a3725b035e882b/tests/test_piped.py. I initially used `sudo apt-get remove xz-utils`, but it turns out that there’s another `xz` binary in `/home/linuxbrew/.linuxbrew/bin/xz`.