### PR TITLE
When an output process fails, print a possible cause

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -260,9 +260,17 @@ class PipedCompressionWriter(Closing):
         retcode = self.process.wait()
         self.outfile.close()
         if retcode != 0:
+            try:
+                cause = (
+                    f". Possible cause: {os.strerror(retcode)}" if retcode > 1 else ""
+                )
+            except ValueError:
+                cause = ""
             raise OSError(
-                "Output {} process terminated with exit code {}".format(
-                    " ".join(self._program_args), retcode
+                "Output process '{}' terminated with exit code {}{}".format(
+                    " ".join(self._program_args),
+                    retcode,
+                    cause,
                 )
             )
 


### PR DESCRIPTION
See marcelm/cutadapt#640.

When the disk is full, Cutadapt currently prints this:
```
$ cutadapt -j 2 -o full/disk/output.fastq.gz input.fastq.gz
...
ERROR: cutadapt: error: Output pigz process terminated with exit code 28
```
With this PR, the message is:
```
ERROR: cutadapt: error: Output process 'pigz --no-name' terminated with exit code 28. Possible cause: No space left on device
```
So pigz sets its exit code to something that `os.strerror()` can turn into a human-readable string.

Becuse this doesn’t work with `igzip` (where the exit code is 252), the message just says "possible" cause:
```
ERROR: cutadapt: error: Output process 'igzip --no-name' terminated with exit code 252. Possible cause: Unknown error 252
```
