### PR TITLE
Add better type hints for xopen()

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ package_dir =
 packages = find:
 install_requires =
     isal>=1.0.0; platform.python_implementation == 'CPython' and (platform.machine == "x86_64" or platform.machine == "AMD64")
+    typing_extensions; python_version<'3.8'
 
 [options.packages.find]
 where = src

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -72,6 +72,9 @@ except OSError:  # Catches file not found and permission errors. Possible other 
     _MAX_PIPE_SIZE = None
 
 
+FilePath = Union[str, bytes, os.PathLike]
+
+
 def _available_cpu_count() -> int:
     """
     Number of available virtual or physical CPUs on this system
@@ -164,7 +167,7 @@ class PipedCompressionWriter(Closing):
 
     def __init__(
         self,
-        path: Union[str, bytes, os.PathLike],
+        path: FilePath,
         program_args: List[str],
         mode="wt",
         compresslevel: Optional[int] = None,
@@ -301,7 +304,7 @@ class PipedCompressionReader(Closing):
 
     def __init__(
         self,
-        path: Union[str, bytes, os.PathLike],
+        path: FilePath,
         program_args: List[Union[str, bytes]],
         mode: str = "r",
         threads_flag: Optional[str] = None,
@@ -1003,9 +1006,7 @@ def _open_reproducible_gzip(filename, mode, compresslevel):
     return gzip_file
 
 
-def _detect_format_from_content(
-    filename: Union[str, bytes, os.PathLike]
-) -> Optional[str]:
+def _detect_format_from_content(filename: FilePath) -> Optional[str]:
     """
     Attempts to detect file format from the content by reading the first
     6 bytes. Returns None if no format could be detected.
@@ -1046,7 +1047,7 @@ def _detect_format_from_extension(filename: Union[str, bytes]) -> Optional[str]:
 
 @overload
 def xopen(
-    filename: Union[str, bytes, os.PathLike],
+    filename: FilePath,
     mode: Literal["r", "w", "a", "rt", "wt", "at"] = ...,
     compresslevel: Optional[int] = ...,
     threads: Optional[int] = ...,
@@ -1061,7 +1062,7 @@ def xopen(
 
 @overload
 def xopen(
-    filename: Union[str, bytes, os.PathLike],
+    filename: FilePath,
     mode: Literal["rb", "wb", "ab"],
     compresslevel: Optional[int] = ...,
     threads: Optional[int] = ...,
@@ -1075,7 +1076,7 @@ def xopen(
 
 
 def xopen(  # noqa: C901  # The function is complex, but readable.
-    filename: Union[str, bytes, os.PathLike],
+    filename: FilePath,
     mode: Literal["r", "w", "a", "rt", "rb", "wt", "wb", "at", "ab"] = "r",
     compresslevel: Optional[int] = None,
     threads: Optional[int] = None,

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1046,7 +1046,7 @@ def _detect_format_from_extension(filename: Union[str, bytes]) -> Optional[str]:
 
 @overload
 def xopen(
-    filename: Union[str, bytes, os.PathLike[str]],
+    filename: Union[str, bytes, os.PathLike],
     mode: Literal["r", "w", "a", "rt", "wt", "at"] = ...,
     compresslevel: Optional[int] = ...,
     threads: Optional[int] = ...,
@@ -1061,7 +1061,7 @@ def xopen(
 
 @overload
 def xopen(
-    filename: Union[str, bytes, os.PathLike[str]],
+    filename: Union[str, bytes, os.PathLike],
     mode: Literal["rb", "wb", "ab"],
     compresslevel: Optional[int] = ...,
     threads: Optional[int] = ...,
@@ -1075,7 +1075,7 @@ def xopen(
 
 
 def xopen(  # noqa: C901  # The function is complex, but readable.
-    filename: Union[str, bytes, os.PathLike[str]],
+    filename: Union[str, bytes, os.PathLike],
     mode: Literal["r", "w", "a", "rt", "rb", "wt", "wb", "at", "ab"] = "r",
     compresslevel: Optional[int] = None,
     threads: Optional[int] = None,

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -33,7 +33,12 @@ import tempfile
 import time
 from abc import ABC, abstractmethod
 from subprocess import Popen, PIPE, DEVNULL
-from typing import Optional, Union, TextIO, AnyStr, IO, List, Set
+from typing import Optional, Union, TextIO, AnyStr, IO, List, Set, overload, BinaryIO
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 from ._version import version as __version__
 
@@ -1039,15 +1044,45 @@ def _detect_format_from_extension(filename: Union[str, bytes]) -> Optional[str]:
     return None
 
 
+@overload
+def xopen(
+    filename: Union[str, bytes, os.PathLike[str]],
+    mode: Literal["r", "w", "a", "rt", "wt", "at"] = ...,
+    compresslevel: Optional[int] = ...,
+    threads: Optional[int] = ...,
+    *,
+    encoding: str = ...,
+    errors: Optional[str] = ...,
+    newline: Optional[str] = ...,
+    format: Optional[str] = ...,
+) -> TextIO:
+    ...
+
+
+@overload
+def xopen(
+    filename: Union[str, bytes, os.PathLike[str]],
+    mode: Literal["rb", "wb", "ab"],
+    compresslevel: Optional[int] = ...,
+    threads: Optional[int] = ...,
+    *,
+    encoding: str = ...,
+    errors: None = ...,
+    newline: None = ...,
+    format: Optional[str] = ...,
+) -> BinaryIO:
+    ...
+
+
 def xopen(  # noqa: C901  # The function is complex, but readable.
-    filename: Union[str, bytes, os.PathLike],
-    mode: str = "r",
+    filename: Union[str, bytes, os.PathLike[str]],
+    mode: Literal["r", "w", "a", "rt", "rb", "wt", "wb", "at", "ab"] = "r",
     compresslevel: Optional[int] = None,
     threads: Optional[int] = None,
     *,
-    encoding="utf-8",
-    errors=None,
-    newline=None,
+    encoding: str = "utf-8",
+    errors: Optional[str] = None,
+    newline: Optional[str] = None,
     format: Optional[str] = None,
 ) -> IO:
     """
@@ -1088,7 +1123,7 @@ def xopen(  # noqa: C901  # The function is complex, but readable.
     extension. Possible values are "gz", "xz" and "bz2".
     """
     if mode in ("r", "w", "a"):
-        mode += "t"
+        mode += "t"  # type: ignore
     if mode not in ("rt", "rb", "wt", "wb", "at", "ab"):
         raise ValueError("Mode '{}' not supported".format(mode))
     filename = os.fspath(filename)
@@ -1120,7 +1155,7 @@ def xopen(  # noqa: C901  # The function is complex, but readable.
     elif detected_format == "bz2":
         opened_file = _open_bz2(filename, mode, threads, **text_mode_kwargs)
     else:
-        opened_file = open(filename, mode, **text_mode_kwargs)
+        opened_file = open(filename, mode, **text_mode_kwargs)  # type: ignore
 
     # The "write" method for GzipFile is very costly. Lots of python calls are
     # made. To a lesser extent this is true for LzmaFile and BZ2File. By

--- a/tox.ini
+++ b/tox.ini
@@ -43,3 +43,4 @@ extend_ignore = E731
 exclude_lines =
     pragma: no cover
     def __repr__
+    @overload


### PR DESCRIPTION
With this, xopen(..., mode="rb") correctly gets the return type "BinaryIO" and xopen(..., mode="rt") gets the return type TextIO.

Using this code from typeshed as a template:
https://github.com/python/typeshed/blob/fe3a34503cb54f30c932c329d40e615be14c1ddf/stdlib/builtins.pyi#L1432

To do: 
```
ImportError while loading conftest '/home/runner/work/xopen/xopen/tests/conftest.py'.
tests/conftest.py:6: in <module>
    from xopen import xopen
.tox/py/lib/python3.7/site-packages/xopen/__init__.py:1057: in <module>
    format: Optional[str] = ...,
E   TypeError: 'ABCMeta' object is not subscriptable
```