### PR TITLE
Recommend isal on PyPy and aarch64 platforms

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ package_dir =
     =src
 packages = find:
 install_requires =
-    isal>=1.0.0; platform.python_implementation == 'CPython' and (platform.machine == "x86_64" or platform.machine == "AMD64")
+    isal>=1.0.0; platform.machine == "x86_64" or platform.machine == "AMD64" or platform.machine == "aarch64"
     typing_extensions; python_version<'3.8'
 
 [options.packages.find]


### PR DESCRIPTION
I did some benchmarks on my olimex olinuxino A64 with allwinner A64 chip. (AArch64 architecture). This was to ascertain the performance of python-zlib-ng. I also took python-isal into the comparison.

It appears that isal and zlib-ng do not speed up decompression, but both do speed up compression. In fact, isal is three times faster at the levels it supports.

I removed aarch64 support once: https://github.com/pycompression/xopen/pull/79. But that was before I made python-isal into a C-module. Apparently the Cython module had some performance issues on aarch64. Luckily isal and zlib-ng python modules are both implemented in C now. 

This is a quick and easy PR. I guess I should add zlib-ng now.

As for PyPy, I do run the full test suite and it works. Generally PyPy is very slow in calling C-extensions, but that is an overhead that applies equally to all deflate libraries.