### PR TITLE
Add zlib-ng and refactor gzip open functions.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ package_dir =
 packages = find:
 install_requires =
     isal>=1.0.0; platform.python_implementation == 'CPython' and (platform.machine == "x86_64" or platform.machine == "AMD64")
+    zlib-ng>=0.1.0; platform.machine == "x86_64" or platform.machine == "AMD64" or platform.machine == "aarch64"
     typing_extensions; python_version<'3.8'
 
 [options.packages.find]

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1102,15 +1102,7 @@ def _open_external_gzip_writer(
     filename, mode, compresslevel, threads, **text_mode_kwargs
 ):
     assert mode in ("wt", "wb", "at", "ab")
-    if compresslevel is None:
-        preferred_applications = [
-            PipedIGzipWriter,
-            PipedPythonIsalWriter,
-            PipedPythonZlibNGWriter,
-            functools.partial(PipedPigzWriter, threads=threads),
-            PipedGzipWriter,
-        ]
-    elif compresslevel < 3:
+    if compresslevel is None or compresslevel < 3:
         preferred_applications = [
             PipedIGzipWriter,
             PipedPythonIsalWriter,
@@ -1120,7 +1112,7 @@ def _open_external_gzip_writer(
         ]
     else:
         # ISA-L level 3 is very similar in compression to levels 1 and 2.
-        # prefer zlib-ng instead for better compression.
+        # prefer zlib-ng instead for better compression at levels higher than 2.
         preferred_applications = [
             PipedPythonZlibNGWriter,
             PipedIGzipWriter,
@@ -1210,11 +1202,11 @@ def _open_reproducible_gzip(filename, mode, compresslevel):
         mtime=0,
     )
 
-    if compresslevel is None:
-        preferred_classes = [igzip_class, gzip_ng_class, gzip_class]
-    elif compresslevel < 3:
+    if compresslevel is None or compresslevel < 3:
         preferred_classes = [igzip_class, gzip_ng_class, gzip_class]
     else:
+        # ISA-L level 3 is very similar in compression to levels 1 and 2.
+        # prefer zlib-ng instead for better compression at levels higher than 2.
         preferred_classes = [gzip_ng_class, igzip_class, gzip_class]
 
     last_error = None

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1162,13 +1162,13 @@ def _open_gz(filename, mode: str, compresslevel, threads, **text_mode_kwargs):
     return g
 
 
-def gzip_class(*args, compresslevel, **kwargs):
+def _gzip_class(*args, compresslevel, **kwargs):
     if compresslevel is None:
         compresslevel = zlib.Z_DEFAULT_COMPRESSION
     return gzip.GzipFile(*args, compresslevel=compresslevel, **kwargs)
 
 
-def igzip_class(*args, compresslevel, **kwargs):
+def _igzip_class(*args, compresslevel, **kwargs):
     if igzip is None:
         raise ValueError("No igzip available")
     if compresslevel is None:
@@ -1176,7 +1176,7 @@ def igzip_class(*args, compresslevel, **kwargs):
     return igzip.IGzipFile(*args, compresslevel=compresslevel, **kwargs)
 
 
-def gzip_ng_class(*args, compresslevel, **kwargs):
+def _gzip_ng_class(*args, compresslevel, **kwargs):
     if gzip_ng is None:
         raise ValueError("No gzip_ng available")
     if compresslevel is None:
@@ -1203,11 +1203,11 @@ def _open_reproducible_gzip(filename, mode, compresslevel):
     )
 
     if compresslevel is None or compresslevel < 3:
-        preferred_classes = [igzip_class, gzip_ng_class, gzip_class]
+        preferred_classes = [_igzip_class, _gzip_ng_class, _gzip_class]
     else:
         # ISA-L level 3 is very similar in compression to levels 1 and 2.
         # prefer zlib-ng instead for better compression at levels higher than 2.
-        preferred_classes = [gzip_ng_class, igzip_class, gzip_class]
+        preferred_classes = [_gzip_ng_class, _igzip_class, _gzip_class]
 
     last_error = None
     for klass in preferred_classes:

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1173,24 +1173,27 @@ def _open_reproducible_gzip(filename, mode, compresslevel):
         except ValueError:
             # Compression level not supported, move to gzip_ng or builtin gzip.
             pass
-    if gzip_ng is not None:
-        gzip_file = gzip_ng.GzipNGFile(
-            **kwargs,
-            compresslevel=zlib.Z_DEFAULT_COMPRESSION if compresslevel is None
-            # Compresslevel 1 results in files that are typically 50% larger
-            # than zlib. So in that case use level 2, which is more similar
-            # to zlib and also still faster.
-            else max(compresslevel, 2),
-        )
+
     if gzip_file is None:
-        gzip_file = gzip.GzipFile(
-            **kwargs,
-            # Override gzip.open's default of 9 for consistency
-            # with command-line gzip.
-            compresslevel=zlib.Z_DEFAULT_COMPRESSION
-            if compresslevel is None
-            else compresslevel,
-        )
+        if gzip_ng is not None:
+            gzip_file = gzip_ng.GzipNGFile(
+                **kwargs,
+                compresslevel=zlib.Z_DEFAULT_COMPRESSION if compresslevel is None
+                # Compresslevel 1 results in files that are typically 50%
+                # larger
+                # than zlib. So in that case use level 2, which is more similar
+                # to zlib and also still faster.
+                else max(compresslevel, 2),
+            )
+        else:
+            gzip_file = gzip.GzipFile(
+                **kwargs,
+                # Override gzip.open's default of 9 for consistency
+                # with command-line gzip.
+                compresslevel=zlib.Z_DEFAULT_COMPRESSION
+                if compresslevel is None
+                else compresslevel,
+            )
     # When (I)GzipFile is created with a fileobj instead of a filename,
     # the passed file object is not closed when (I)GzipFile.close()
     # is called. This forces it to be closed.

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1196,11 +1196,15 @@ def _open_reproducible_gzip(filename, mode, compresslevel):
         else:
             compresslevel = zlib.Z_DEFAULT_COMPRESSION
     if gzip_ng is not None:
-        preferred_class = [gzip_ng.GzipNGFile] + preferred_class
         # Compresslevel 1 results in files that are typically 50% larger than
         # zlib. So in that case use level 2, which is more similar to zlib and
         # also still faster.
-        compresslevel = max(compresslevel, 2)
+        def zlibng_class_opener(*args, compresslevel, **kwargs):
+            return gzip_ng.GzipNGFile(
+                *args, compresslevel=max(compresslevel, 2), **kwargs
+            )
+
+        preferred_class = [zlibng_class_opener] + preferred_class
     if igzip is not None:
         preferred_class = [igzip.IGzipFile] + preferred_class
     last_error = None

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -898,6 +898,9 @@ class PipedPythonIsalReader(PipedCompressionReader):
     def __init__(
         self, path, mode: str = "r", *, encoding="utf-8", errors=None, newline=None
     ):
+        if not igzip:
+            # Raise error here, otherwise it will occur during write.
+            raise OSError("isal module not installed.")
         super().__init__(
             path,
             [sys.executable, "-m", "isal.igzip"],
@@ -919,6 +922,9 @@ class PipedPythonIsalWriter(PipedCompressionWriter):
         errors=None,
         newline=None,
     ):
+        if not igzip:
+            # Raise error here, otherwise it will occur during write.
+            raise OSError("isal module not installed.")
         if compresslevel is not None and compresslevel not in range(0, 4):
             raise ValueError("compresslevel must be between 0 and 3")
         super().__init__(
@@ -936,6 +942,9 @@ class PipedPythonZlibNGReader(PipedCompressionReader):
     def __init__(
         self, path, mode: str = "r", *, encoding="utf-8", errors=None, newline=None
     ):
+        if not gzip_ng:
+            # Raise error here, otherwise it will occur during write.
+            raise OSError("zlib-ng module not installed.")
         super().__init__(
             path,
             [sys.executable, "-m", "zlib_ng.gzip_ng"],
@@ -957,6 +966,9 @@ class PipedPythonZlibNGWriter(PipedCompressionWriter):
         errors=None,
         newline=None,
     ):
+        if not gzip_ng:
+            # Raise error here, otherwise it will occur during write.
+            raise OSError("zlib-ng module not installed.")
         if compresslevel is not None and compresslevel not in range(1, 10):
             raise ValueError("compresslevel must be between 1 and 10")
         if compresslevel == 1:

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
 
 import functools
 import gzip
+import platform
 import sys
 import io
 import os
@@ -1069,7 +1070,7 @@ def _open_external_gzip_reader(
     filename, mode, compresslevel, threads, **text_mode_kwargs
 ):
     assert mode in ("rt", "rb")
-    if sys.platform == "AMD64" or sys.platform == "x86_64":
+    if platform.machine() == "AMD64" or platform.machine() == "x86_64":
         # For x86-64 there are optimized libraries available for decompression
         preferred_applications = [
             PipedIGzipReader,

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1100,7 +1100,7 @@ def _open_external_gzip_writer(
             )
         except ValueError:  # Wrong compression level
             pass
-    elif gzip_ng:
+    if gzip_ng:
         return PipedPythonZlibNGWriter(
             filename, mode, compresslevel, **text_mode_kwargs
         )

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -62,7 +62,7 @@ except ImportError:
 
 try:
     from zlib_ng import gzip_ng
-except:
+except ImportError:
     gzip_ng = None
 
 try:
@@ -1100,13 +1100,10 @@ def _open_external_gzip_writer(
             )
         except ValueError:  # Wrong compression level
             pass
-    if gzip_ng:
-        try:
-            return PipedPythonZlibNGWriter(
-                filename, mode, compresslevel, **text_mode_kwargs
-            )
-        except ValueError:  # Wrong compression level
-            pass
+    elif gzip_ng:
+        return PipedPythonZlibNGWriter(
+            filename, mode, compresslevel, **text_mode_kwargs
+        )
     try:
         return PipedPigzWriter(
             filename, mode, compresslevel, threads=threads, **text_mode_kwargs

--- a/tests/test_piped.py
+++ b/tests/test_piped.py
@@ -25,6 +25,8 @@ from xopen import (
     PipedIGzipWriter,
     PipedPythonIsalReader,
     PipedPythonIsalWriter,
+    PipedPythonZlibNGReader,
+    PipedPythonZlibNGWriter,
     PipedXzReader,
     PipedXzWriter,
     PipedZstdReader,
@@ -32,6 +34,7 @@ from xopen import (
     _MAX_PIPE_SIZE,
     _can_read_concatenated_gz,
     igzip,
+    gzip_ng,
 )
 
 extensions = ["", ".gz", ".bz2", ".xz", ".zst"]
@@ -76,6 +79,9 @@ def available_gzip_readers_and_writers():
     if igzip is not None:
         readers.append(PipedPythonIsalReader)
         writers.append(PipedPythonIsalWriter)
+    if gzip_ng is not None:
+        readers.append(PipedPythonZlibNGReader)
+        writers.append(PipedPythonZlibNGWriter)
     return readers, writers
 
 

--- a/tests/test_piped.py
+++ b/tests/test_piped.py
@@ -340,6 +340,8 @@ def writers_and_levels():
         elif writer == PipedIGzipWriter or writer == PipedPythonIsalWriter:
             # Levels 0-3 are supported
             yield from ((writer, i) for i in range(4))
+        elif writer == PipedPythonZlibNGWriter:
+            yield from ((writer, i) for i in range(1, 10))
         else:
             raise NotImplementedError(
                 f"Test should be implemented for " f"{writer}"

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -259,7 +259,11 @@ def test_invalid_compression_level(tmp_path):
     with pytest.raises(ValueError) as e:
         with xopen(tmp_path / "out.gz", mode="w", compresslevel=17) as f:
             f.write("hello")  # pragma: no cover
-    assert "compresslevel must be" in e.value.args[0]
+    # The value error should warn about compresslevel or about an invalid
+    # initialization option.
+    assert (
+        "compresslevel must be" in e.value.args[0] or "nitialization" in e.value.args[0]
+    )
 
 
 @pytest.mark.parametrize("ext", extensions)


### PR DESCRIPTION
I added zlib-ng. This is great, but now we also have three competing  library implementations for opening deflate compressed files:
- zlib
- ISA-L
- zlib-ng

Each of these has their own implementation programs as well. This means the choice for the "best" application becomes more situational. Also it is hard to correctly set all the initialization options.

I have therefore refactored the code. A list of preferred implementations is made. Then using a for loop and a try except the list is tried in order for an application that works. Application-specific options are set using functool.partial

This leads to more verbose code, but also in much simpler logic. Therefore this solution scales better. Since I expect crabz to be added soon, it is much easier to do that in this codebase.

Also this will work wonders for coverage as all the individual PipedCompression Readers and Writers are tested separately anyway and (almost) all the code in the opening functions is touched as there is only a single opening code line within a for loop.
It should be much more robust this way.