### PR TITLE
Write returns number of written bytes

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -268,8 +268,8 @@ class PipedCompressionWriter(Closing):
         process = Popen(program_args + extra_args, **kwargs)  # type: ignore
         return process
 
-    def write(self, arg: AnyStr) -> None:
-        self._file.write(arg)
+    def write(self, arg: AnyStr) -> int:
+        return self._file.write(arg)
 
     def close(self) -> None:
         if self.closed:


### PR DESCRIPTION
Maybe this issue would have been caught earlier if PipedCompressionWriter inherited from an abstract IO base class? It is something that should probably be done at some point. (Although I don't feel the urgency currently).

Fixes #127