### PR TITLE
Use python-isal's igzip_threaded module to replace igzip piping.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
           optional-deps: false
         - os: ubuntu-20.04
           python-version: "3.10"
+          with-python-isal: false
+          optional-deps: true
+        - os: ubuntu-20.04
+          python-version: "3.10"
           optional-deps: false
           with-python-isal: false
           with-zstandard: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,16 +36,19 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9"]
         optional-deps: [true]
+        with-python-isal: [true]
         include:
         - os: macos-latest
           python-version: "3.10"
           optional-deps: true
         - os: ubuntu-20.04
           python-version: "3.10"
+          with-python-isal: false
           optional-deps: false
         - os: ubuntu-20.04
           python-version: "3.10"
           optional-deps: false
+          with-python-isal: false
           with-zstandard: true
         - os: windows-latest
           python-version: "3.10"
@@ -70,6 +73,10 @@ jobs:
       run: python -m pip install tox
     - name: Test
       run: tox -e py
+      if: matrix.with-python-isal
+    - name: Test without python-isal
+      run: tox -e no-isal
+      if: true && !matrix.with-python-isal
     - name: Test with zstandard
       if: matrix.with-zstandard
       run: tox -e zstd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.7"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9"]
         optional-deps: [true]
         include:
         - os: macos-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,13 +13,12 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 package_dir =
     =src
 packages = find:
 install_requires =
     isal>=1.4.1; platform.machine == "x86_64" or platform.machine == "AMD64" or platform.machine == "aarch64"
-    typing_extensions; python_version<'3.8'
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ package_dir =
     =src
 packages = find:
 install_requires =
-    isal>=1.4.0; platform.machine == "x86_64" or platform.machine == "AMD64" or platform.machine == "aarch64"
+    isal>=1.4.1; platform.machine == "x86_64" or platform.machine == "AMD64" or platform.machine == "aarch64"
     typing_extensions; python_version<'3.8'
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ package_dir =
     =src
 packages = find:
 install_requires =
-    isal>=1.0.0; platform.machine == "x86_64" or platform.machine == "AMD64" or platform.machine == "aarch64"
+    isal>=1.4.0; platform.machine == "x86_64" or platform.machine == "AMD64" or platform.machine == "aarch64"
     typing_extensions; python_version<'3.8'
 
 [options.packages.find]

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -86,7 +86,9 @@ try:
     _MAX_PIPE_SIZE = int(
         _MAX_PIPE_SIZE_PATH.read_text(encoding="ascii")
     )  # type: Optional[int]
-except OSError:  # Catches file not found and permission errors. Possible other errors too.
+except (
+    OSError
+):  # Catches file not found and permission errors. Possible other errors too.
     _MAX_PIPE_SIZE = None
 
 
@@ -1052,7 +1054,9 @@ def _open_external_gzip_writer(
         return PipedGzipWriter(filename, mode, compresslevel, **text_mode_kwargs)
 
 
-def _open_gz(filename, mode: str, compresslevel, threads, **text_mode_kwargs):
+def _open_gz(  # noqa: C901
+    filename, mode: str, compresslevel, threads, **text_mode_kwargs
+):
     assert mode in ("rt", "rb", "wt", "wb", "at", "ab")
     # With threads == 0 igzip_threaded defers to igzip.open, but that is not
     # desirable as a reproducible header is required.

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1050,7 +1050,7 @@ def _open_gz(filename, mode: str, compresslevel, threads, **text_mode_kwargs):
     assert mode in ("rt", "rb", "wt", "wb", "at", "ab")
     # With threads == 0 igzip_threaded defers to igzip.open, but that is not
     # desirable as a reproducible header is required.
-    if igzip_threaded and threads != 0:
+    if threads != 0:
         try:
             return igzip_threaded.open(
                 filename,
@@ -1061,9 +1061,9 @@ def _open_gz(filename, mode: str, compresslevel, threads, **text_mode_kwargs):
                 **text_mode_kwargs,
                 threads=1 if threads is None else threads,
             )
-        except ValueError:  # Wrong compression level
+        except (AttributeError, ValueError):
+            # Igzip_threaded is None or wrong compression level
             pass
-    if threads != 0:
         try:
             if "r" in mode:
                 return _open_external_gzip_reader(

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1048,6 +1048,8 @@ def _open_external_gzip_writer(
 
 def _open_gz(filename, mode: str, compresslevel, threads, **text_mode_kwargs):
     assert mode in ("rt", "rb", "wt", "wb", "at", "ab")
+    # With threads == 0 igzip_threaded defers to igzip.open, but that is not
+    # desirable as a reproducible header is required.
     if igzip_threaded and threads != 0:
         try:
             return igzip_threaded.open(

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1056,7 +1056,7 @@ def _open_gz(filename, mode: str, compresslevel, threads, **text_mode_kwargs):
     assert mode in ("rt", "rb", "wt", "wb", "at", "ab")
     # With threads == 0 igzip_threaded defers to igzip.open, but that is not
     # desirable as a reproducible header is required.
-    if threads != 0:
+    if igzip_threaded and threads != 0:
         try:
             return igzip_threaded.open(  # type: ignore
                 filename,
@@ -1067,9 +1067,9 @@ def _open_gz(filename, mode: str, compresslevel, threads, **text_mode_kwargs):
                 **text_mode_kwargs,
                 threads=1 if threads is None else threads,
             )
-        except (AttributeError, ValueError):
-            # Igzip_threaded is None or wrong compression level
+        except ValueError:  # Wrong compression level
             pass
+    if threads != 0:
         try:
             if "r" in mode:
                 return _open_external_gzip_reader(

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1055,7 +1055,8 @@ def _open_gz(filename, mode: str, compresslevel, threads, **text_mode_kwargs):
             return igzip_threaded.open(
                 filename,
                 mode,
-                isal_zlib.ISAL_DEFAULT_COMPRESSION if compresslevel is None
+                isal_zlib.ISAL_DEFAULT_COMPRESSION
+                if compresslevel is None
                 else compresslevel,
                 **text_mode_kwargs,
                 threads=1 if threads is None else threads,

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1053,9 +1053,10 @@ def _open_gz(filename, mode: str, compresslevel, threads, **text_mode_kwargs):
             return igzip_threaded.open(
                 filename,
                 mode,
-                compresslevel or isal_zlib.ISAL_DEFAULT_COMPRESSION,
+                isal_zlib.ISAL_DEFAULT_COMPRESSION if compresslevel is None
+                else compresslevel,
                 **text_mode_kwargs,
-                threads=threads or 1,
+                threads=1 if threads is None else threads,
             )
         except ValueError:  # Wrong compression level
             pass

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1048,7 +1048,7 @@ def _open_external_gzip_writer(
 
 def _open_gz(filename, mode: str, compresslevel, threads, **text_mode_kwargs):
     assert mode in ("rt", "rb", "wt", "wb", "at", "ab")
-    if igzip_threaded:
+    if igzip_threaded and threads != 0:
         try:
             return igzip_threaded.open(
                 filename,

--- a/tests/test_piped.py
+++ b/tests/test_piped.py
@@ -260,7 +260,7 @@ def test_concatenated_gzip_function():
     reason="Pipe size modifications not available on this platform.",
 )
 def test_pipesize_changed(tmp_path, monkeypatch):
-    # Higher compression level to avoid openingen with threaded opener
+    # Higher compression level to avoid opening with threaded opener
     with xopen(tmp_path / "hello.gz", "wb", compresslevel=5) as f:
         assert isinstance(f, PipedCompressionWriter)
         assert fcntl.fcntl(f._file.fileno(), fcntl.F_GETPIPE_SZ) == _MAX_PIPE_SIZE

--- a/tests/test_piped.py
+++ b/tests/test_piped.py
@@ -259,8 +259,9 @@ def test_concatenated_gzip_function():
     not hasattr(fcntl, "F_GETPIPE_SZ") or _MAX_PIPE_SIZE is None,
     reason="Pipe size modifications not available on this platform.",
 )
-def test_pipesize_changed(tmp_path):
-    with xopen(tmp_path / "hello.gz", "wb") as f:
+def test_pipesize_changed(tmp_path, monkeypatch):
+    # Higher compression level to avoid openingen with threaded opener
+    with xopen(tmp_path / "hello.gz", "wb", compresslevel=5) as f:
         assert isinstance(f, PipedCompressionWriter)
         assert fcntl.fcntl(f._file.fileno(), fcntl.F_GETPIPE_SZ) == _MAX_PIPE_SIZE
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,11 @@ deps =
     {[testenv]deps}
     zstandard
 
+[testenv:no-isal]
+commands=
+    pip uninstall -y isal
+    {[testenv]commands}
+
 [testenv:black]
 basepython = python3.10
 deps = black==22.3.0


### PR DESCRIPTION
Hi Marcel,

Sorry I haven't worked on my dnaio PR lately. I have been sick and taking my sick leave. Currently I am taking an algorithms for genomics course in Deflt, which is very enjoyable. 4 hours of travel everyday, yet I am still full of energy due to pure excitement. 

I have been working a lot on python-isal lately because sequali was taking a lot of time to handle a gzipped dataset and I wanted to use more threads. Unfortunately with xopen it is not possible to track the progress in the file due to it being opened by an external process. Also there is quite some overhead using the piped solution.

So I tried to write a mutlithread solution. Unfortunately it proved hard to escape the GIL. So I rewrote the entire gzip reading process in C (https://github.com/pycompression/python-isal/pull/151). This has the fortunate side effect of removing most python overhead for single-threaded decompression as well and also making BGZIP format decompression a lot faster.

After that I wrote multithreaded readers and writers. https://github.com/pycompression/python-isal/pull/153
Then I needed to do some polishing with several PRs to get a satisfying result but I think I got there.

Here are the benchmarks for reading using sequali. Sequali is compute bound so spawning a separate gzip thread significantly decreases wall clock time. 

Using xopen current main branch
```
Benchmark 1: sequali ~/test/5millionreads_R1.fastq.gz
  Time (mean ± σ):      4.735 s ±  0.188 s    [User: 6.366 s, System: 1.034 s]
  Range (min … max):    4.518 s …  4.934 s    5 runs
 ```

Using this branch on xopen
```
Benchmark 1: sequali ~/test/5millionreads_R1.fastq.gz
  Time (mean ± σ):      4.510 s ±  0.028 s    [User: 6.126 s, System: 0.261 s]
  Range (min … max):    4.478 s …  4.550 s    5 runs
 ```

As you can see it is a slight win in wall clock time, but also a massive win in system time, due to the system not having to manage a pipe and the program being able to take advantage of shared memory.

For comparison, decompression using no threads, and benchmarking no compressed data.
```
Benchmark 1: sequali ~/test/5millionreads_R1.fastq.gz
  Time (mean ± σ):      5.824 s ±  0.073 s    [User: 5.588 s, System: 0.234 s]
  Range (min … max):    5.748 s …  5.913 s    5 runs

Benchmark 1: sequali ~/test/5millionreads_R1.fastq
  Time (mean ± σ):      4.108 s ±  0.017 s    [User: 3.805 s, System: 0.303 s]
  Range (min … max):    4.085 s …  4.123 s    5 runs
```

Writing benchmarks. I tried to use cutadapt for this, but since that uses multiprocessing internally that got a little messy. So I wrote a simple dnaio read write script that only uses xopen threads:
```python3
import dnaio
import sys

with dnaio.open(sys.argv[1], mode="r", open_threads=1, qualities=True) as reader:
    with dnaio.open(sys.argv[2], mode="w", open_threads=1, qualities=True) as writer:
        for record in reader:
            writer.write(record)
```

Before, using main branch
```
Benchmark 1: python dnaio_read_and_write.py ~/test/5millionreads_R1.fastq ramdisk/test.fastq.gz
  Time (mean ± σ):      3.326 s ±  0.034 s    [User: 4.875 s, System: 1.078 s]
  Range (min … max):    3.298 s …  3.384 s    5 runs
```

After, this branch
```
Benchmark 1: python dnaio_read_and_write.py ~/test/5millionreads_R1.fastq ramdisk/test.fastq.gz
  Time (mean ± σ):      3.164 s ±  0.014 s    [User: 5.035 s, System: 0.577 s]
  Range (min … max):    3.151 s …  3.187 s    5 runs
```
That is with threads=1, but using more than one thread is also possible. Below threads=2
```
Benchmark 1: python dnaio_read_and_write.py ~/test/5millionreads_R1.fastq ramdisk/test.fastq.gz
  Time (mean ± σ):      2.984 s ±  0.016 s    [User: 5.660 s, System: 0.757 s]
  Range (min … max):    2.964 s …  3.007 s    5 runs
```
There is a slight increase in user time and a decrease in system time when using one thread. Overall the threaded solution saves a small percentage of compute time compared to the piped solution. Two threads can further decrease wall clock time, but it is only advisable when the bottleneck is quite severe. Seems very little applications will break the 500MiBs barrier I think that one thread is a very sane default.

Main advantages of this change:
- Less compute time in all situations.
- The install base for python-isal is better than igzip
- The changes from python-isal can be carried over the python-zlib-ng. Then I can redo #124 in a much simpler fashion. Also this will give access to multithreaded zlib-ng compression level 5, finally eliminating one of cutadapt's bottlenecks on default settings. 

It was quite a lot of work to get everything working in an efficient way in python-isal, but I think all this work will pay off in the long run. All these compressions and decompressions do add up over time.
