### PR TITLE
Do not use piped igzip anymore

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1026,12 +1026,6 @@ def _open_external_gzip_reader(
 ):
     assert mode in ("rt", "rb")
     try:
-        return PipedIGzipReader(filename, mode, **text_mode_kwargs)
-    except (OSError, ValueError):
-        # No igzip installed or version does not support reading
-        # concatenated files.
-        pass
-    try:
         return PipedPigzReader(filename, mode, threads=threads, **text_mode_kwargs)
     except OSError:
         return PipedGzipReader(filename, mode, **text_mode_kwargs)
@@ -1041,11 +1035,6 @@ def _open_external_gzip_writer(
     filename, mode, compresslevel, threads, **text_mode_kwargs
 ):
     assert mode in ("wt", "wb", "at", "ab")
-    try:
-        return PipedIGzipWriter(filename, mode, compresslevel, **text_mode_kwargs)
-    except (OSError, ValueError):
-        # No igzip installed or compression level higher than 3
-        pass
     try:
         return PipedPigzWriter(
             filename, mode, compresslevel, threads=threads, **text_mode_kwargs
@@ -1252,8 +1241,8 @@ def xopen(  # noqa: C901  # The function is complex, but readable.
     gzip: 6, xz: 6, zstd: 3.
 
     When threads is None (the default), compressed file formats are read or written
-    using a pipe to a subprocess running an external tool such as ``igzip``,
-    ``pbzip2``, ``pigz`` etc., see PipedIGzipWriter, PipedIGzipReader etc.
+    using a pipe to a subprocess running an external tool such as,
+    ``pbzip2``, ``gzip`` etc., see PipedGzipWriter, PipedGzipReader etc.
     If the external tool supports multiple threads, *threads* can be set to an int
     specifying the number of threads to use.
     If no external tool supporting the compression format is available, the file is


### PR DESCRIPTION
Piped igzip is worse than python-isal's igzip_threaded module, but it is better than anything else.

But we have to consider the install base as well. My suspicion is that the only treason why people install igzip is because that is a dependency of xopen in conda and they install it automatically. If their platform supports igzip, it supports python-isal too. The python-isal conda package is build for the same architectures.

So the decision to remove it from the xopen decision tree is rather easy. What follows is the decision what to do about PipedIgzipReader and PipedIgzipWriter. I vote to put a DeprecationWarning in these classes and remove them one year after the release where they have been deprecated occurs. I doubt anyone is using them directly, and if so, we can always remove the deprecation later if people complain.

I want to see how xopen 1.8.0 does now it is released on Conda. There maybe some lingering bugs in the igzip_threaded module that can only be found with extensive use. Most bugs in python-isal are reported within one month after a release though. So after one or two months I will do the multithreaded thing to python-zlib-ng (using the powers of copy-paste) and integrate that in xopen. 

After that I feel that pigz should follow the same path as igzip. Pigz does not have a wide install base, it will be slower than python-zlib-ng. zlib-ng has a tremendously wide architecture support, there is no platform on conda that will not be able to run it. So as a result there will be little, if any users, that can install pigz, but not python-zlib-ng. Gzip will be universally installed on any linux system. It is even on alpine linux images (as part of busybox), so it does make sense to leave that in.

A niche case might be users that install cutadapt through debian packages. I see  that python3-xopen has a dependency on pigz. (But curiously enough, not on isal, even though that is available through the debian packaging system). 

I am just gonna leave this here as something to ponder about before the next release.

EDIT: And the PipedPythonIsalReader and PipedPythonIsalIgzipWriter should also be deprecated of course. 