### PR TITLE
Add zlib-ng

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,23 +36,23 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9"]
         optional-deps: [true]
-        with-python-isal: [true]
+        with-libs: [true]
         include:
         - os: macos-latest
           python-version: "3.10"
           optional-deps: true
         - os: ubuntu-20.04
           python-version: "3.10"
-          with-python-isal: false
+          with-libs: false
           optional-deps: false
         - os: ubuntu-20.04
           python-version: "3.10"
-          with-python-isal: false
+          with-libs: false
           optional-deps: true
         - os: ubuntu-20.04
           python-version: "3.10"
           optional-deps: false
-          with-python-isal: false
+          with-libs: false
           with-zstandard: true
         - os: windows-latest
           python-version: "3.10"
@@ -77,10 +77,10 @@ jobs:
       run: python -m pip install tox
     - name: Test
       run: tox -e py
-      if: matrix.with-python-isal
-    - name: Test without python-isal
-      run: tox -e no-isal
-      if: true && !matrix.with-python-isal
+      if: matrix.with-libs
+    - name: Test without python-isal and python-zlib-ng
+      run: tox -e no-libs
+      if: true && !matrix.with-libs
     - name: Test with zstandard
       if: matrix.with-zstandard
       run: tox -e zstd

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,10 @@ To ensure that you get the correct ``zstandard`` version, you can specify the ``
 Changelog
 ---------
 
+in-development
+~~~~~~~~~~~~~~~~~~~
+* #135: xopen now uses zlib-ng when available and applicable.
+
 v1.8.0 (2023-11-03)
 ~~~~~~~~~~~~~~~~~~~
 * #131: xopen now defers to the ``isal.igzip_threaded`` module rather than

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ classifiers = [
 requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
-    'isal>=1.4.1; platform.machine == "x86_64" or platform.machine == "AMD64" or platform.machine == "aarch64"'
+    'isal>=1.4.1; platform.machine == "x86_64" or platform.machine == "AMD64" or platform.machine == "aarch64"',
+    'zlib-ng>=0.4.0; platform.machine == "x86_64" or platform.machine == "AMD64" or platform.machine == "aarch64"'
 ]
 
 [project.urls]

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -1070,13 +1070,16 @@ def _open_gz(  # noqa: C901
         except ValueError:  # Wrong compression level
             pass
     if gzip_ng_threaded and threads != 0:
-        return gzip_ng_threaded.open(
-            filename,
-            mode,
-            zlib_ng.Z_DEFAULT_COMPRESSION if compresslevel is None else compresslevel,
-            **text_mode_kwargs,
-            threads=1 if threads is None else threads,
-        )
+        try:
+            return gzip_ng_threaded.open(
+                filename,
+                mode,
+                zlib_ng.Z_DEFAULT_COMPRESSION if compresslevel is None else compresslevel,
+                **text_mode_kwargs,
+                threads=1 if threads is None else threads,
+            )
+        except zlib_ng.error:  # Bad compression level
+            pass
     if threads != 0:
         try:
             if "r" in mode:

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -58,6 +58,9 @@ BUFFER_SIZE = max(io.DEFAULT_BUFFER_SIZE, 128 * 1024)
 igzip: Optional[ModuleType]
 isal_zlib: Optional[ModuleType]
 igzip_threaded: Optional[ModuleType]
+zlib_ng: Optional[ModuleType]
+gzip_ng: Optional[ModuleType]
+gzip_ng_threaded: Optional[ModuleType]
 
 try:
     from isal import igzip, igzip_threaded, isal_zlib
@@ -1070,7 +1073,7 @@ def _open_gz(  # noqa: C901
             )
         except ValueError:  # Wrong compression level
             pass
-    if gzip_ng_threaded and threads != 0:
+    if gzip_ng_threaded and zlib_ng and threads != 0:
         try:
             if compresslevel is None:
                 level = zlib_ng.Z_DEFAULT_COMPRESSION

--- a/tests/test_piped.py
+++ b/tests/test_piped.py
@@ -261,7 +261,7 @@ def test_concatenated_gzip_function():
 )
 def test_pipesize_changed(tmp_path, monkeypatch):
     # Higher compression level to avoid opening with threaded opener
-    with xopen(tmp_path / "hello.gz", "wb", compresslevel=5) as f:
+    with PipedGzipWriter(tmp_path / "hello.gz", "wb", compresslevel=5) as f:
         assert isinstance(f, PipedCompressionWriter)
         assert fcntl.fcntl(f._file.fileno(), fcntl.F_GETPIPE_SZ) == _MAX_PIPE_SIZE
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,9 @@ deps =
     {[testenv]deps}
     zstandard
 
-[testenv:no-isal]
+[testenv:no-libs]
 commands=
-    pip uninstall -y isal
+    pip uninstall -y isal zlib-ng
     {[testenv]commands}
 
 [testenv:black]


### PR DESCRIPTION
Add zlib-ng, including its threaded interface. 

This PR is much less extensive than #124. 

Benchmarks!

```
import argparse

import xopen

if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument("input")
    parser.add_argument("output")
    parser.add_argument("--threads", type=int, default=1)
    parser.add_argument("--level", type=int, default=5)
    args = parser.parse_args()

    with open(args.input, "rb") as fin:
        with xopen.xopen(args.output, mode="wb", compresslevel=args.level,
                         threads=args.threads) as fout:
            while True:
                block = fin.read(128 * 1024)
                if block == b"":
                    break
                fout.write(block)
```

before: (4 threads + level 5 is current cutadapt default)
```
Benchmark 1: python benchmark_xopen.py --level 4 --threads 4  ~/test/5millionreads_R1.fastq ramdisk/out.fastq.gz
  Time (mean ± σ):      6.963 s ±  0.019 s    [User: 27.845 s, System: 2.475 s]
  Range (min … max):    6.941 s …  6.994 s    5 runs
370M    ramdisk/out.fastq.gz

Benchmark 1: python benchmark_xopen.py --level 5 --threads 4  ~/test/5millionreads_R1.fastq ramdisk/out.fastq.gz
  Time (mean ± σ):     13.101 s ±  0.420 s    [User: 52.276 s, System: 2.460 s]
  Range (min … max):   12.754 s … 13.724 s    5 runs
357M    ramdisk/out.fastq.gz

Benchmark 1: python benchmark_xopen.py --level 6 --threads 4  ~/test/5millionreads_R1.fastq ramdisk/out.fastq.gz
  Time (mean ± σ):     31.231 s ±  0.303 s    [User: 124.932 s, System: 2.215 s]
  Range (min … max):   31.024 s … 31.764 s    5 runs
340M    ramdisk/out.fastq.gz

```

after:
```
Benchmark 1: python benchmark_xopen.py --level 4 --threads 4  ~/test/5millionreads_R1.fastq ramdisk/out.fastq.gz
  Time (mean ± σ):      6.254 s ±  0.028 s    [User: 24.670 s, System: 0.601 s]
  Range (min … max):    6.227 s …  6.290 s    5 runs
352M    ramdisk/out.fastq.gz

Benchmark 1: python benchmark_xopen.py --level 5 --threads 4  ~/test/5millionreads_R1.fastq ramdisk/out.fastq.gz
  Time (mean ± σ):      7.656 s ±  0.021 s    [User: 30.262 s, System: 0.666 s]
  Range (min … max):    7.630 s …  7.683 s    5 runs
343M    ramdisk/out.fastq.gz

Benchmark 1: python benchmark_xopen.py --level 6 --threads 4  ~/test/5millionreads_R1.fastq ramdisk/out.fastq.gz
  Time (mean ± σ):     12.377 s ±  0.143 s    [User: 49.126 s, System: 0.630 s]
  Range (min … max):   12.278 s … 12.627 s    5 runs
332M    ramdisk/out.fastq.gz
```

Looks like zlib-ng level 5 uses much less time than zlib level 5, so this is a great improvement for cutadapt. Going back to level 4 cuts down 20% of compute time while going back to zlib level 5 size. Not really worth it if filesize is an important consideration. Level 6 suffers immensely from diminishing returns and is not worth it for such big files IMO.

Python-isal handles levels 1 to 3. These have similar size results.  Just added level 1 for comparison. This is not affected by this PR.

```
Benchmark 1: python benchmark_xopen.py --level 1 --threads 4  ~/test/5millionreads_R1.fastq ramdisk/out.fastq.gz
  Time (mean ± σ):      1.087 s ±  0.063 s    [User: 4.037 s, System: 0.601 s]
  Range (min … max):    0.996 s …  1.150 s    5 runs
387M    ramdisk/out.fastq.gz

Benchmark 1: python benchmark_xopen.py --level 1 --threads 1  ~/test/5millionreads_R1.fastq ramdisk/out.fastq.gz
  Time (mean ± σ):      2.758 s ±  0.055 s    [User: 2.756 s, System: 0.323 s]
  Range (min … max):    2.668 s …  2.812 s    5 runs
 ```