### PR TITLE
Drop end of copyright year range

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2021 xopen developers
+Copyright (c) 2010 The xopen developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
See   

* https://hynek.me/til/copyright-years/
* https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code

Since the commit message is going to be visible "forever" on the GitHub landing page for this project next to the file, I set it to just 'MIT license' on purpose.