### PR TITLE
Only open files in binary modes and use io.TextIOWrapper only at the highest-level function.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,6 +184,11 @@ To ensure that you get the correct ``zstandard`` version, you can specify the ``
 Changelog
 ---------
 
+in-development
+~~~~~~~~~~~~~~~~~~~
+* #146: PipedCompressionReader/Writer are now binary-only. For text reading
+  they are wrapped in an ``io.TextIOWrapper`` in the ``xopen()`` function.
+
 v1.9.0 (2024-01-31)
 ~~~~~~~~~~~~~~~~~~~
 * #142: The python-isal compression backend is now only used for compression


### PR DESCRIPTION
This prevents passing all the textmode keyword arguments `encoding`, `errors` and `newline` to every function in the stack. PipedCompressionReader and Writer are converted to binary only.

This is quite a simplification but has some backwards-incompatible changes for people using PipedCompressionReader and Writer directly. Since we never documented those classes as a public interface, I think this change is fine (EDIT: As long as this becomes 2.0.0 of course).

fixes #141 
