### PR TITLE
Invoke PipedCompressionProgram directly rather than through subclassing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,8 +186,16 @@ Changelog
 
 in-development
 ~~~~~~~~~~~~~~~~~~~
-* #146: PipedCompressionReader/Writer are now binary-only. For text reading
-  they are wrapped in an ``io.TextIOWrapper`` in the ``xopen()`` function.
+* #146, #147, #148: Various refactors for better code size and readability:
+
+    * PipedCompressionReader/Writer are now combined _PipedCompressionProgram
+      class.
+    * _PipedCompressionProgram is binary-only. For text reading and writing
+      it is wrapped in an ``io.TextIOWrapper`` in the ``xopen()`` function.
+    * Classes that derive from PipedCompressionReader/Writer have been removed.
+* #148: xopen's classes, variables and functions pertaining to piped reading
+  and writing are all made private by prefixing them with an underscore.
+  These are not part of the API and may change between releases.
 
 v1.9.0 (2024-01-31)
 ~~~~~~~~~~~~~~~~~~~

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -166,30 +166,6 @@ def _set_pipe_size_to_max(fd: int) -> None:
         pass
 
 
-def _can_read_concatenated_gz(program: str) -> bool:
-    """
-    Check if a concatenated gzip file can be read properly. Not all deflate
-    programs handle this properly.
-    """
-    fd, temp_path = tempfile.mkstemp(suffix=".gz", prefix="xopen.")
-    try:
-        # Create a concatenated gzip file. gzip.compress recreates the contents
-        # of a gzip file including header and trailer.
-        with open(temp_path, "wb") as temp_file:
-            temp_file.write(gzip.compress(b"AB") + gzip.compress(b"CD"))
-        try:
-            result = subprocess.run(
-                [program, "-c", "-d", temp_path], check=True, stderr=PIPE, stdout=PIPE
-            )
-            return result.stdout == b"ABCD"
-        except subprocess.CalledProcessError:
-            # Program can't read zip
-            return False
-    finally:
-        os.close(fd)
-        os.remove(temp_path)
-
-
 class _PipedCompressionProgram(io.IOBase):
     """
     Read and write compressed files by running an external process and piping into it.

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -492,9 +492,7 @@ def _open_zst(  # noqa: C901
     return f
 
 
-def _open_gz(  # noqa: C901
-    filename, mode: str, compresslevel, threads, **text_mode_kwargs
-):
+def _open_gz(filename, mode: str, compresslevel, threads, **text_mode_kwargs):
     assert "b" in mode
     if compresslevel is None:
         # Force the same compression level on every tool regardless of
@@ -523,18 +521,14 @@ def _open_gz(  # noqa: C901
                 )
             except zlib_ng.error:  # Bad compression level
                 pass
-        try:
+
+        for program in ("pigz", "gzip"):
             try:
                 return _PipedCompressionProgram(
-                    filename, mode, compresslevel, threads, **_program_settings("pigz")
+                    filename, mode, compresslevel, threads, **_program_settings(program)
                 )
             except OSError:
-                return _PipedCompressionProgram(
-                    filename, mode, compresslevel, threads, **_program_settings("gzip")
-                )
-        except OSError:
-            pass  # We try without threads.
-
+                pass  # We try without threads.
     return _open_reproducible_gzip(
         filename,
         mode=mode,

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -177,7 +177,7 @@ class _PipedCompressionProgram(io.IOBase):
         mode="rb",
         compresslevel: Optional[int] = None,
         threads: Optional[int] = None,
-        program_args: Optional[Sequence[str]] = None,
+        program_args: Sequence[str] = ("gzip", "--no-name"),
         threads_flag: Optional[str] = None,
         # This exit code is not interpreted as an error when terminating the process
         allowed_exit_code: Optional[int] = -signal.SIGTERM,
@@ -195,8 +195,6 @@ class _PipedCompressionProgram(io.IOBase):
             used. At the moment, this means that the number of available CPU cores is used, capped
             at four to avoid creating too many threads. Use 0 to use all available cores.
         """
-        if program_args is None:
-            program_args = ("gzip", "--no-name")
         self._error_raised = False
         self._program_args = list(program_args)
         self._allowed_exit_code = allowed_exit_code

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -109,7 +109,7 @@ class _ProgramSettings(typing.NamedTuple):
     allowed_exit_message: Optional[bytes] = None
 
 
-PROGRAM_SETTINGS: Dict[str, _ProgramSettings] = {
+_PROGRAM_SETTINGS: Dict[str, _ProgramSettings] = {
     "pbzip2": _ProgramSettings(
         ("pbzip2",),
         tuple(range(1, 10)),
@@ -125,7 +125,7 @@ PROGRAM_SETTINGS: Dict[str, _ProgramSettings] = {
 
 
 def _program_settings(program: str) -> Dict[str, Any]:
-    return PROGRAM_SETTINGS[program]._asdict()
+    return _PROGRAM_SETTINGS[program]._asdict()
 
 
 def _available_cpu_count() -> int:

--- a/tests/test_piped.py
+++ b/tests/test_piped.py
@@ -13,17 +13,9 @@ from itertools import cycle
 
 from xopen import (
     xopen,
-    PipedCompressionProgram,
-    PipedGzipProgram,
-    PipedPBzip2Program,
-    PipedPigzProgram,
-    PipedIGzipProgram,
-    PipedPythonIsalProgram,
-    PipedXzProgram,
-    PipedZstdProgram,
+    _PipedCompressionProgram,
     _MAX_PIPE_SIZE,
-    _can_read_concatenated_gz,
-    igzip,
+    _program_settings,
 )
 
 extensions = ["", ".gz", ".bz2", ".xz", ".zst"]
@@ -44,37 +36,24 @@ CONTENT = b"".join(CONTENT_LINES)
 
 
 def available_gzip_programs():
-    programs = [
-        klass
-        for prog, klass in [
-            ("gzip", PipedGzipProgram),
-            ("pigz", PipedPigzProgram),
-            ("igzip", PipedIGzipProgram),
-        ]
-        if shutil.which(prog)
-    ]
-    if PipedIGzipProgram in programs and not _can_read_concatenated_gz("igzip"):
-        programs.remove(PipedIGzipProgram)
-    if igzip is not None:
-        programs.append(PipedPythonIsalProgram)
-    return programs
+    return [_program_settings(prog) for prog in ("gzip", "pigz") if shutil.which(prog)]
 
 
 def available_bzip2_programs():
     if shutil.which("pbzip2"):
-        return [PipedPBzip2Program]
+        return [_program_settings("pbzip2")]
     return []
 
 
 def available_xz_programs():
     if shutil.which("xz"):
-        return [PipedXzProgram]
+        return [_program_settings("xz")]
     return []
 
 
 def available_zstd_programs():
     if shutil.which("zstd"):
-        return [PipedZstdProgram]
+        return [_program_settings("zstd")]
     return []
 
 
@@ -91,9 +70,11 @@ ALL_PROGRAMS_WITH_EXTENSION = (
 )
 
 
-THREADED_PROGRAMS = {(PipedPigzProgram, ".gz"), (PipedPBzip2Program, ".bz2")} & set(
-    ALL_PROGRAMS_WITH_EXTENSION
-)
+THREADED_PROGRAMS = [
+    settings
+    for settings in ALL_PROGRAMS_WITH_EXTENSION
+    if "pbzip2" in settings[0]["program_args"] or "pigz" in settings[0]["program_args"]
+]
 
 
 @pytest.fixture(params=PIPED_GZIP_PROGRAMS)
@@ -117,74 +98,88 @@ def writer(request):
 
 
 def test_reader_readinto(reader):
-    opener, extension = reader
-    content = CONTENT
-    with opener(TEST_DIR / f"file.txt{extension}", "rb") as f:
-        b = bytearray(len(content) + 100)
+    program_settings, extension = reader
+    with _PipedCompressionProgram(
+        TEST_DIR / f"file.txt{extension}", "rb", **program_settings
+    ) as f:
+        b = bytearray(len(CONTENT) + 100)
         length = f.readinto(b)
-        assert length == len(content)
-        assert b[:length] == content
+        assert length == len(CONTENT)
+        assert b[:length] == CONTENT
 
 
 def test_reader_textiowrapper(reader):
-    opener, extension = reader
-    with opener(TEST_DIR / f"file.txt{extension}", "rb") as f:
+    program_settings, extension = reader
+    with _PipedCompressionProgram(
+        TEST_DIR / f"file.txt{extension}", "rb", **program_settings
+    ) as f:
         wrapped = io.TextIOWrapper(f, encoding="utf-8")
         assert wrapped.read() == CONTENT.decode("utf-8")
 
 
 def test_reader_readline(reader):
-    opener, extension = reader
-    first_line = CONTENT_LINES[0]
-    with opener(TEST_DIR / f"file.txt{extension}", "rb") as f:
-        assert f.readline() == first_line
+    program_settings, extension = reader
+    with _PipedCompressionProgram(
+        TEST_DIR / f"file.txt{extension}",
+        "rb",
+        **program_settings,
+    ) as f:
+        assert f.readline() == CONTENT_LINES[0]
 
 
 def test_reader_readlines(reader):
-    opener, extension = reader
-    with opener(TEST_DIR / f"file.txt{extension}", "r") as f:
+    program_settings, extension = reader
+    with _PipedCompressionProgram(
+        TEST_DIR / f"file.txt{extension}", "rb", **program_settings
+    ) as f:
         assert f.readlines() == CONTENT_LINES
 
 
 @pytest.mark.parametrize("threads", [None, 1, 2])
 def test_piped_reader_iter(threads, threaded_reader):
-    opener, extension = threaded_reader
-    with opener(TEST_DIR / f"file.txt{extension}", mode="r", threads=threads) as f:
+    program_settings, extension = threaded_reader
+    with _PipedCompressionProgram(
+        TEST_DIR / f"file.txt{extension}",
+        "rb",
+        **program_settings,
+    ) as f:
         lines = list(f)
         assert lines[0] == CONTENT_LINES[0]
 
 
 def test_writer(tmp_path, writer):
-    opener, extension = writer
-    print(opener, writer)
-    print(repr(opener))
+    program_settings, extension = writer
     path = tmp_path / f"out{extension}"
-    with opener(path, mode="wb") as f:
-        print(f)
+    with _PipedCompressionProgram(path, mode="wb", **program_settings) as f:
         f.write(b"hello")
     with xopen(path, mode="rb") as f:
         assert f.read() == b"hello"
 
 
 def test_writer_has_iter_method(tmp_path, writer):
-    opener, extension = writer
-    with opener(tmp_path / f"out{extension}", "wb") as f:
+    program_settings, extension = writer
+    path = tmp_path / f"out{extension}"
+    with _PipedCompressionProgram(
+        path,
+        mode="wb",
+        **program_settings,
+    ) as f:
         f.write(b"hello")
         assert hasattr(f, "__iter__")
 
 
 def test_reader_iter_without_with(reader):
-    opener, extension = reader
-    f = opener(TEST_DIR / f"file.txt{extension}")
+    program_settings, extension = reader
+    f = _PipedCompressionProgram(TEST_DIR / f"file.txt{extension}", **program_settings)
     it = iter(f)
     assert CONTENT_LINES[0] == next(it)
     f.close()
 
 
 def test_reader_close(reader, create_large_file):
-    reader, extension = reader
+    program_settings, extension = reader
     large_file = create_large_file(extension)
-    with reader(large_file, mode="rb") as f:
+    with _PipedCompressionProgram(large_file, "rb", **program_settings) as f:
         f.readline()
         time.sleep(0.2)
     # The subprocess should be properly terminated now
@@ -192,81 +187,97 @@ def test_reader_close(reader, create_large_file):
 
 def test_invalid_gzip_compression_level(gzip_writer, tmp_path):
     with pytest.raises(ValueError) as e:
-        with gzip_writer(tmp_path / "out.gz", mode="w", compresslevel=17) as f:
-            f.write("hello")  # pragma: no cover
+        with _PipedCompressionProgram(
+            tmp_path / "out.gz",
+            mode="w",
+            compresslevel=17,
+            **gzip_writer,
+        ) as f:
+            f.write(b"hello")  # pragma: no cover
     assert "compresslevel must be" in e.value.args[0]
 
 
 def test_invalid_xz_compression_level(tmp_path):
     with pytest.raises(ValueError) as e:
-        with PipedXzProgram(tmp_path / "out.xz", mode="w", compresslevel=10) as f:
-            f.write("hello")  # pragma: no cover
+        with _PipedCompressionProgram(
+            tmp_path / "out.xz",
+            mode="w",
+            compresslevel=17,
+            **_program_settings("xz"),
+        ) as f:
+            f.write(b"hello")  # pragma: no cover
     assert "compresslevel must be" in e.value.args[0]
 
 
 def test_invalid_zstd_compression_level(tmp_path):
     with pytest.raises(ValueError) as e:
-        with PipedZstdProgram(tmp_path / "out.zst", mode="w", compresslevel=25) as f:
-            f.write("hello")  # pragma: no cover
+        with _PipedCompressionProgram(
+            tmp_path / "out.zst",
+            mode="w",
+            compresslevel=25,
+            **_program_settings("zstd"),
+        ) as f:
+            f.write(b"hello")  # pragma: no cover
     assert "compresslevel must be" in e.value.args[0]
 
 
 def test_readers_read(reader):
-    opener, extension = reader
-    with opener(TEST_DIR / f"file.txt{extension}", "rb") as f:
+    program_settings, extension = reader
+    with _PipedCompressionProgram(
+        TEST_DIR / f"file.txt{extension}", "rb", **program_settings
+    ) as f:
         assert f.read() == CONTENT
-
-
-@pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="Windows does not have a gzip application by default.",
-)
-def test_concatenated_gzip_function():
-    assert _can_read_concatenated_gz("gzip") is True
-    assert _can_read_concatenated_gz("pigz") is True
-    assert _can_read_concatenated_gz("cat") is False
 
 
 @pytest.mark.skipif(
     not hasattr(fcntl, "F_GETPIPE_SZ") or _MAX_PIPE_SIZE is None,
     reason="Pipe size modifications not available on this platform.",
 )
-def test_pipesize_changed(tmp_path, monkeypatch):
+def test_pipesize_changed(tmp_path):
     # Higher compression level to avoid opening with threaded opener
-    with PipedGzipProgram(tmp_path / "hello.gz", "wb", compresslevel=5) as f:
-        assert isinstance(f, PipedCompressionProgram)
+    with _PipedCompressionProgram(tmp_path / "hello.gz", "wb", compresslevel=5) as f:
         assert fcntl.fcntl(f._file.fileno(), fcntl.F_GETPIPE_SZ) == _MAX_PIPE_SIZE
 
 
 def test_pipedcompressionwriter_wrong_mode(tmp_path):
     with pytest.raises(ValueError) as error:
-        PipedCompressionProgram(tmp_path / "test", ["gzip"], "xb")
+        _PipedCompressionProgram(tmp_path / "test", "xb")
     error.match("Mode is 'xb', but it must be")
 
 
 def test_pipedcompressionwriter_wrong_program(tmp_path):
     with pytest.raises(OSError):
-        PipedCompressionProgram(tmp_path / "test", ["XVXCLSKDLA"], "wb")
+        _PipedCompressionProgram(
+            tmp_path / "test",
+            "wb",
+            program_args=[
+                "XVXCLSKDLA",
+            ],
+        )
 
 
 def test_compression_level(tmp_path, gzip_writer):
     # Currently only the gzip writers handle compression levels.
     path = tmp_path / "test.gz"
-    with gzip_writer(path, "wb", 2) as test_h:
+    with _PipedCompressionProgram(path, "wb", 2, **gzip_writer) as test_h:
         test_h.write(b"test")
     assert gzip.decompress(path.read_bytes()) == b"test"
 
 
 def test_iter_method_writers(writer, tmp_path):
-    opener, extension = writer
-    writer = opener(tmp_path / f"test{extension}", "wb")
+    program_settings, extension = writer
+    writer = _PipedCompressionProgram(
+        tmp_path / f"test{extension}", "wb", **program_settings
+    )
     assert iter(writer) == writer
     writer.close()
 
 
 def test_next_method_writers(writer, tmp_path):
-    opener, extension = writer
-    writer = opener(tmp_path / f"test{extension}", "wb")
+    program_settings, extension = writer
+    writer = _PipedCompressionProgram(
+        tmp_path / f"test{extension}", "wb", **program_settings
+    )
     with pytest.raises(io.UnsupportedOperation) as error:
         next(writer)
     error.match("read")
@@ -275,14 +286,14 @@ def test_next_method_writers(writer, tmp_path):
 
 def test_pipedcompressionprogram_wrong_mode():
     with pytest.raises(ValueError) as error:
-        PipedCompressionProgram("test", ["gzip"], "xb")
+        _PipedCompressionProgram("test", "xb")
     error.match("Mode is 'xb', but it must be")
 
 
 def test_piped_compression_reader_peek_binary(reader):
-    opener, extension = reader
+    program_settings, extension = reader
     filegz = TEST_DIR / f"file.txt{extension}"
-    with opener(filegz, "rb") as read_h:
+    with _PipedCompressionProgram(filegz, "rb", **program_settings) as read_h:
         # Peek returns at least the amount of characters but maybe more
         # depending on underlying stream. Hence startswith not ==.
         assert read_h.peek(1).startswith(b"T")
@@ -292,9 +303,9 @@ def test_piped_compression_reader_peek_binary(reader):
     sys.platform != "win32", reason="seeking only works on Windows for now"
 )
 def test_piped_compression_reader_seek_and_tell(reader):
-    opener, extension = reader
+    program_settings, extension = reader
     filegz = TEST_DIR / f"file.txt{extension}"
-    with opener(filegz, "rb") as f:
+    with _PipedCompressionProgram(filegz, "rb", **program_settings) as f:
         original_position = f.tell()
         assert f.read(4) == b"Test"
         f.seek(original_position)
@@ -303,23 +314,20 @@ def test_piped_compression_reader_seek_and_tell(reader):
 
 @pytest.mark.parametrize("mode", ["r", "rb"])
 def test_piped_compression_reader_peek_text(reader, mode):
-    opener, extension = reader
+    program_settings, extension = reader
     compressed_file = TEST_DIR / f"file.txt{extension}"
-    with opener(compressed_file, mode) as read_h:
+    with _PipedCompressionProgram(compressed_file, mode, **program_settings) as read_h:
         assert read_h.peek(1)[0] == CONTENT[0]
 
 
 def writers_and_levels():
     for writer in PIPED_GZIP_PROGRAMS:
-        if writer == PipedGzipProgram:
+        if "gzip" in writer["program_args"]:
             # Levels 1-9 are supported
             yield from ((writer, i) for i in range(1, 10))
-        elif writer == PipedPigzProgram:
+        elif "pigz" in writer["program_args"]:
             # Levels 0-9 + 11 are supported
             yield from ((writer, i) for i in list(range(10)) + [11])
-        elif writer == PipedIGzipProgram or writer == PipedPythonIsalProgram:
-            # Levels 0-3 are supported
-            yield from ((writer, i) for i in range(4))
         else:
             raise NotImplementedError(
                 f"Test should be implemented for " f"{writer}"
@@ -329,14 +337,14 @@ def writers_and_levels():
 @pytest.mark.parametrize(["writer", "level"], writers_and_levels())
 def test_valid_compression_levels(writer, level, tmp_path):
     path = tmp_path / "test.gz"
-    with writer(path, "wb", level) as handle:
+    with _PipedCompressionProgram(path, "wb", level, **writer) as handle:
         handle.write(b"test")
     assert gzip.decompress(path.read_bytes()) == b"test"
 
 
 def test_reproducible_gzip_compression(gzip_writer, tmp_path):
     path = tmp_path / "file.gz"
-    with gzip_writer(path, mode="wb") as f:
+    with _PipedCompressionProgram(path, mode="wb", **gzip_writer) as f:
         f.write(b"hello")
 
     data = path.read_bytes()
@@ -347,14 +355,14 @@ def test_reproducible_gzip_compression(gzip_writer, tmp_path):
 def test_piped_tool_fails_on_close(tmp_path):
     # This test exercises the retcode != 0 case in PipedCompressionWriter.close()
     with pytest.raises(OSError) as e:
-        with PipedCompressionProgram(
+        with _PipedCompressionProgram(
             tmp_path / "out.txt",
-            [
+            "wb",
+            program_args=[
                 sys.executable,
                 "-c",
                 "import sys\nfor line in sys.stdin: pass\nprint()\nsys.exit(5)",
             ],
-            mode="wb",
         ) as f:
             f.write(b"Hello")
     assert "exit code 5" in e.value.args[0]

--- a/tests/test_piped.py
+++ b/tests/test_piped.py
@@ -100,13 +100,14 @@ def writer(request):
 
 def test_reader_readinto(reader):
     program_settings, extension = reader
+    content = CONTENT
     with _PipedCompressionProgram(
         TEST_DIR / f"file.txt{extension}", "rb", program_settings=program_settings
     ) as f:
-        b = bytearray(len(CONTENT) + 100)
+        b = bytearray(len(content) + 100)
         length = f.readinto(b)
-        assert length == len(CONTENT)
-        assert b[:length] == CONTENT
+        assert length == len(content)
+        assert b[:length] == content
 
 
 def test_reader_textiowrapper(reader):


### PR DESCRIPTION
This is basically this Jack Diederich video in practice: https://www.youtube.com/watch?v=o9pEzgHorH0

Subclassing to derive settings is not the best way in this case. 

By moving all the program specific arguments to a dedicated _ProgramSettings class, we can use a _ProgramSettings class for each different program. These settings classes are now in one central place in the code, rather than spread out over multiple class definitions. 

+ Less code
+ Easier to see which programs are used
+ Easier to add new programs

I also made _PipedCompressionProgram a private class.

EDIT: Changed to reflected changes after review.