### PR TITLE
Support previously opened filehandles as input to xopen.open()

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -664,7 +664,7 @@ def xopen(
 
 
 def xopen(  # noqa: C901  # The function is complex, but readable.
-    file: FileOrPath,
+    file: FileOrPath = None,
     mode: Literal["r", "w", "a", "rt", "rb", "wt", "wb", "at", "ab"] = "r",
     compresslevel: Optional[int] = None,
     threads: Optional[int] = None,
@@ -728,6 +728,8 @@ def xopen(  # noqa: C901  # The function is complex, but readable.
     if filename is not None:
         print("WARNING: filename argument is deprecated. Use file !", file=sys.stderr)
         file = filename
+    if not file:
+        raise ValueError("No file provided")
     if hasattr(file, "name") and isinstance(file, io.IOBase):
         # If file is an IO object, use its name attribute
         file_name: str = os.path.realpath(file.name)

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -566,3 +566,67 @@ def test_xopen_zst_fails_when_zstandard_not_available(monkeypatch):
     with pytest.raises(ImportError):
         with xopen.xopen(TEST_DIR / "file.txt.zst", mode="rb", threads=0) as f:
             f.read()
+
+
+# tests for passing in filehandles
+def test_passing_in_gz_filehandles_for_reading():
+    first_line = CONTENT_LINES[0].encode("utf-8")
+    with open(TEST_DIR / "file.txt.gz", "rb") as fh:
+        with xopen(fh, "rb") as f:
+            assert f.readline() == first_line
+
+
+def test_passing_in_xz_filehandles_for_reading():
+    first_line = CONTENT_LINES[0].encode("utf-8")
+    with open(TEST_DIR / "file.txt.xz", "rb") as fh:
+        with xopen(fh, "rb") as f:
+            assert f.readline() == first_line
+
+
+def test_passing_in_bz2_filehandles_for_reading():
+    first_line = CONTENT_LINES[0].encode("utf-8")
+    with open(TEST_DIR / "file.txt.bz2", "rb") as fh:
+        with xopen(fh, "rb") as f:
+            assert f.readline() == first_line
+
+
+def test_passing_in_zst_filehandles_for_reading():
+    first_line = CONTENT_LINES[0].encode("utf-8")
+    with open(TEST_DIR / "file.txt.zst", "rb") as fh:
+        with xopen(fh, "rb") as f:
+            assert f.readline() == first_line
+
+
+def test_passing_in_gz_filehandles_for_writing(tmp_path):
+    import isal
+
+    with open(tmp_path / "out.gz", "wb") as fh:
+        with xopen(fh, "wb") as f:
+            assert isinstance(f.raw, isal.igzip_threaded._ThreadedGzipWriter)
+
+
+def test_passing_in_xz_filehandles_for_writing(tmp_path):
+    import xopen
+
+    with open(tmp_path / "out.xz", "wb") as fh:
+        with xopen.xopen(fh, "wb") as f:
+            # for pipedXzProgram, the fh gets passed through
+            assert isinstance(f, xopen.PipedXzProgram)
+
+
+def test_passing_in_bz2_filehandles_for_writing(tmp_path):
+    import xopen
+
+    with open(tmp_path / "out.bz2", "wb") as fh:
+        with xopen.xopen(fh, "wb") as f:
+            # for pipedXzProgram, the fh gets passed through
+            assert isinstance(f, xopen.PipedPBzip2Program)
+
+
+def test_passing_in_zst_filehandles_for_writing(tmp_path):
+    import xopen
+
+    with open(tmp_path / "out.zst", "wb") as fh:
+        with xopen.xopen(fh, "wb") as f:
+            # for pipedXzProgram, the fh gets passed through
+            assert isinstance(f, xopen.PipedZstdProgram)


### PR DESCRIPTION
Minimal changes were applied to support passing open binary filehandles to xopen.xopen(). 

The tests were successful for all supported compression types, for both reading and writing, but I might have missed some of library dependencies.

Use case would be (and tested for) : 
- opening a non-compressed connection to a remote file using smart_open : 

`f_smart = smart_open('s3://mybucket/myfile.fastq.gz','wb', compression='disable')`

- then pass this handle to xopen to perform efficient (de)compression: 

`f = xopen.xopen(f_smart,mode='wb')`


I've noticed some mypy issues in the tox check. These are related to potentially conflicting object types. This could be fixed by explicitly renaming some variables to split flows depending on the input type (afaik). Let me know if you'd want this, or these issues can be ignored/whitelisted (?)
