### PR TITLE
Run black when testing through tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,mypy,py38,py39,py310,py311,py312,pypy3
+envlist = black,flake8,mypy,py38,py39,py310,py311,py312,pypy3
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
I tested locally with `tox` and got confused because I was sure I had incorrectly formatted code. This is very fast du to `skip_install = True`, so we can run this first.