### PR TITLE
Fix reading from a large compressed file using external process

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,12 @@ from xopen import xopen
 def create_large_file(tmp_path):
     def _create_large_file(extension):
         path = tmp_path / f"large{extension}"
-        random_text = "".join(random.choices(string.ascii_lowercase, k=1024))
-        # Make the text a lot bigger in order to ensure that it is larger than the
-        # pipe buffer size.
-        random_text *= 2048
+        random.seed(0)
+        chars = string.ascii_lowercase + "\n"
+        # Do not decrease this length. The generated file needs to have
+        # a certain length after compression to trigger some bugs
+        # (in particular, 512 kB is not sufficient).
+        random_text = "".join(random.choices(chars, k=1024 * 1024))
         with xopen(path, "w") as f:
             f.write(random_text)
         return path

--- a/tests/test_piped.py
+++ b/tests/test_piped.py
@@ -6,7 +6,6 @@ import io
 import os
 import shutil
 import sys
-import time
 import pytest
 from pathlib import Path
 from itertools import cycle
@@ -189,8 +188,6 @@ def test_reader_close(reader, create_large_file):
         large_file, "rb", program_settings=program_settings
     ) as f:
         f.readline()
-        time.sleep(0.2)
-    # The subprocess should be properly terminated now
 
 
 def test_invalid_gzip_compression_level(gzip_writer, tmp_path):


### PR DESCRIPTION
Previously, only the uncompressed data was "large", but issue #160 is only triggered if the *compressed* data is large (in this case, larger than 128 kB), which apparently exceeds some input buffer.

~~This only ensures the tests are failing, no fix yet.~~

This includes an attempt at a fix where the process is first terminated and *then* the reader thread is told to stop.

See #160