### PR TITLE
Drop ubuntu-20.04 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,15 @@ jobs:
         - os: macos-latest
           python-version: "3.10"
           optional-deps: true
-        - os: ubuntu-20.04
+        - os: ubuntu-latest
           python-version: "3.10"
           with-libs: false
           optional-deps: false
-        - os: ubuntu-20.04
+        - os: ubuntu-latest
           python-version: "3.10"
           with-libs: false
           optional-deps: true
-        - os: ubuntu-20.04
+        - os: ubuntu-latest
           python-version: "3.10"
           optional-deps: false
           with-libs: false


### PR DESCRIPTION
GitHub notified me that they will drop the Ubuntu 20.04 runner in April.

This changes the workflow to use ubuntu-latest instead.