### PR TITLE
Use an SPDX license expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools >= 77.0.3", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,10 +10,9 @@ authors = [
 ]
 description = "Open compressed files transparently"
 readme = "README.rst"
-license = {text = "MIT"}
+license = "MIT"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3"
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
This avoids a warning from setuptools, which will stop supporting the old style with "text =" next year.

See https://packaging.python.org/en/latest/specifications/license-expression/