### PR TITLE
Drop support for Python 3.9; start supporting Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9"]
+        # TODO: restore "pypy-3.11" once isal and zlib-ng ship PyPy wheels again
+        # (pycompression/python-isal#245, pycompression/python-zlib-ng#78).
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         optional-deps: [true]
         with-libs: [true]
         include:

--- a/README.rst
+++ b/README.rst
@@ -185,8 +185,8 @@ Changelog
 development version
 ~~~~~~~~~~~~~~~~~~~
 
-* Dropped support for Python 3.8
-* Started supporting Python 3.13
+* Dropped support for Python 3.8 and 3.9
+* Started supporting Python 3.13 and 3.14
 
 v2.0.2 (2024-06-12)
 ~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     'isal>=1.6.1; platform.machine == "x86_64" or platform.machine == "AMD64" or platform.machine == "aarch64"',

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -72,12 +72,6 @@ except ImportError:
 
 try:
     import fcntl
-
-    # fcntl.F_SETPIPE_SZ will be available in python 3.10.
-    # https://github.com/python/cpython/pull/21921
-    # If not available: set it to the correct value for known platforms.
-    if not hasattr(fcntl, "F_SETPIPE_SZ") and sys.platform == "linux":
-        setattr(fcntl, "F_SETPIPE_SZ", 1031)
 except ImportError:
     fcntl = None  # type: ignore
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = black,flake8,mypy,py39,py310,py311,py312,py313,pypy3
+envlist = black,flake8,mypy,py310,py311,py312,py313,py314,pypy3
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Hey @marcelm  @rhpvorderman  - just a quick follow-up to #170, dropping support for 3.9 and adding 3.14 to the CI matrix

I opened a couple PRs upstream (https://github.com/pycompression/python-isal/pull/251, https://github.com/pycompression/python-zlib-ng/pull/79) to build the PyPy wheels for those dependencies. Probably cleanest to merge those in first, but you could also merge this as-is and add the PyPy support back after those are in. (If you go the latter route, it'd probably make sense to take `isal` and `zlib-ng` as CPython-only dependencies here before merge.)

This could easily be folded into #173 (and feel free to cherry-pick it in), just didn't want to step on an existing PR. 